### PR TITLE
Catch gradient error.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PEtab"
 uuid = "48d54b35-e43e-4a66-a5a1-dde6b987cf69"
 authors = ["Viktor Hasselgren", "Sebastian Persson", "Rafael Arutjunjan", "Damiano Ognissanti"]
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/Derivatives/Adjoint_sensitivity_analysis.jl
+++ b/src/Derivatives/Adjoint_sensitivity_analysis.jl
@@ -62,7 +62,7 @@ function computeGradientAdjointDynamicθ(gradient::Vector{Float64},
                                                  petabModel, θ_indices, measurementInfo, parameterInfo, evalVJPSS)
 
         if success == false
-            gradient .= 1e8
+            gradient .= 0.0
             return
         end
     end

--- a/src/Derivatives/Common.jl
+++ b/src/Derivatives/Common.jl
@@ -14,20 +14,6 @@ function getIndicesParametersNotInODESystem(θ_indices::ParameterIndices)::Tuple
 end
 
 
-function couldSolveODEModel(simulationInfo::SimulationInfo, expIDSolve::Vector{Symbol})::Bool
-    for experimentalId in simulationInfo.experimentalConditionId
-        if !(expIDSolve[1] == :all || experimentalId ∈ expIDSolve)
-            continue
-        end
-        if !(simulationInfo.odeSolutionsDerivatives[experimentalId].retcode == ReturnCode.Success ||
-             simulationInfo.odeSolutionsDerivatives[experimentalId].retcode == ReturnCode.Terminated)
-            return false
-        end
-    end
-    return true
-end
-
-
 # Function to compute ∂G∂u and ∂G∂p for an observation assuming a fixed ODE-solution
 function compute∂G∂_(∂G∂_,
                      u::AbstractVector,

--- a/src/Derivatives/Forward_sensitivity_equations.jl
+++ b/src/Derivatives/Forward_sensitivity_equations.jl
@@ -97,6 +97,10 @@ function solveForSensitivites(odeProblem::ODEProblem,
                               splitOverConditions::Bool,
                               isRemade::Bool=false)
 
+    # We need to track a variable if ODE system could be solve as checking retcode on solution array it not enough. 
+    # This is because for ForwardDiff some chunks can solve the ODE, but other fail, and thus if we check the final 
+    # retcode we cannot catch these cases                               
+    simulationInfo.couldSolve[1] = true                              
     petabODECache.S .= 0.0
     if splitOverConditions == false
 
@@ -155,20 +159,7 @@ function solveForSensitivites(odeProblem::ODEProblem,
         end
     end
 
-    # Check retcode of sensitivity matrix ODE solutions
-    success::Bool = true
-    for experimentalId in simulationInfo.experimentalConditionId
-        if expIDSolve[1] != :all && experimentalId ∉ expIDSolve
-            continue
-        end
-        retcode = simulationInfo.odeSolutionsDerivatives[experimentalId].retcode
-        if !(retcode == ReturnCode.Success || retcode == ReturnCode.Terminated)
-            success = false
-            break
-        end
-    end
-
-    return success
+    return simulationInfo.couldSolve[1]
 end
 
 

--- a/src/PEtab_structs.jl
+++ b/src/PEtab_structs.jl
@@ -172,6 +172,7 @@ struct SimulationInfo{T1<:Dict{<:Symbol, <:SciMLBase.DECallback},
     odeSolutions::Dict{Symbol, Union{Nothing, ODESolution}}
     odeSolutionsDerivatives::Dict{Symbol, Union{Nothing, ODESolution}}
     odePreEqulibriumSolutions::Dict{Symbol, Union{Nothing, ODESolution, SciMLBase.NonlinearSolution}}
+    couldSolve::Vector{Bool}
     timeMax::Dict{Symbol, Float64}
     timeObserved::Dict{Symbol, Vector{Float64}}
     iMeasurements::Dict{Symbol, Vector{Int64}}

--- a/src/Process_PEtab_files/Get_simulation_info.jl
+++ b/src/Process_PEtab_files/Get_simulation_info.jl
@@ -98,6 +98,7 @@ function processSimulationInfo(petabModel::PEtabModel,
                                     odeSolutions,
                                     odeSolutionsDerivatives,
                                     odePreEqulibriumSolutions,
+                                    [true], # Bool tracking if we could solve ODE 
                                     timeMax,
                                     timeObserved,
                                     iMeasurementsObserved,

--- a/src/Solve_ODE/Solve_ode_model.jl
+++ b/src/Solve_ODE/Solve_ode_model.jl
@@ -56,9 +56,11 @@ function solveODEAllExperimentalConditions!(odeSolutions::Dict{Symbol, Union{Not
                                                                                petabModel.convertTspan)
             catch e
                 checkError(e)
+                simulationInfo.couldSolve[1] = false
                 return false
             end
             if simulationInfo.odePreEqulibriumSolutions[preEquilibrationId[i]].retcode != ReturnCode.Terminated
+                simulationInfo.couldSolve[1] = false
                 return false
             end
         end
@@ -99,9 +101,11 @@ function solveODEAllExperimentalConditions!(odeSolutions::Dict{Symbol, Union{Not
                                                                       petabModel.convertTspan)
             catch e
                 checkError(e)
+                simulationInfo.couldSolve[1] = false
                 return false
             end
             if odeSolutions[experimentalId].retcode != ReturnCode.Success
+                simulationInfo.couldSolve[1] = false
                 return false
             end
 
@@ -121,10 +125,12 @@ function solveODEAllExperimentalConditions!(odeSolutions::Dict{Symbol, Union{Not
                                                                        petabModel.convertTspan)
             catch e
                 checkError(e)
+                simulationInfo.couldSolve[1] = false
                 return false
             end
             retcode = odeSolutions[experimentalId].retcode
             if !(retcode == ReturnCode.Success || retcode == ReturnCode.Terminated)
+                simulationInfo.couldSolve[1] = false
                 return false
             end
         end


### PR DESCRIPTION
For challenging models a subset of chunks for ForwardDiff might fail, but not all chunks. This can result in the retcode being success, while the gradient is incorrect. We not catch this by having a bool variable being set to false if any error occurred when computing the gradient or Hessian.