### PR TITLE
Use "calibrate" instead of "callibrate"

### DIFF
--- a/docs/src/API_choosen.md
+++ b/docs/src/API_choosen.md
@@ -9,7 +9,7 @@ ODESolverOptions
 SteadyStateSolverOptions
 remakePEtabProblem
 Fides
-callibrateModel
+calibrateModel
 runPEtabSelect
 solveSBMLModel
 ```

--- a/docs/src/Parameter_estimation.md
+++ b/docs/src/Parameter_estimation.md
@@ -36,7 +36,7 @@ Here's an example where we run a 50 multi-start for the Boehm model using the In
 using PyCall
 using Optim
 import QuasiMonteCarlo
-fvals, xvals = callibrateModel(petabProblem, IPNewton(), 
+fvals, xvals = calibrateModel(petabProblem, IPNewton(), 
                                nOptimisationStarts=5, 
                                samplingMethod=QuasiMonteCarlo.LatinHypercubeSample(), 
                                options=Optim.Options(show_trace = false, iterations=200))

--- a/examples/Bachmann.jl
+++ b/examples/Bachmann.jl
@@ -110,5 +110,5 @@ import Pkg;
 Pkg.build("PyCall")
 
 # Set up a fides using the hessian and gradient options in the petabProblem 
-fvals, xvals = callibrateModel(petabProblem, Fides(verbose=true), 
+fvals, xvals = calibrateModel(petabProblem, Fides(verbose=true), 
                                nOptimisationStarts=2)

--- a/examples/Boehm.jl
+++ b/examples/Boehm.jl
@@ -91,7 +91,7 @@ petabProblem.computeHessian!(hessian, p)
 =#
 using Optim
 import QuasiMonteCarlo
-fvals, xvals = callibrateModel(petabProblem, IPNewton(), 
+fvals, xvals = calibrateModel(petabProblem, IPNewton(), 
                                nOptimisationStarts=5, 
                                samplingMethod=QuasiMonteCarlo.LatinHypercubeSample(), 
                                options=Optim.Options(show_trace = false, iterations=200))
@@ -102,7 +102,7 @@ fvals, xvals = callibrateModel(petabProblem, IPNewton(),
     Another popular optimizer is Fides (https://github.com/fides-dev/fides). 
     
     Setting up Fides in Julia is a bit involved, as it is a Python package. Fortunately, we provide a wrapper 
-    and support in callibrate model. 
+    and support in calibrate model. 
 
     As a first step though, PyCall.jl must be built with an environment which has Fides installed.    
 =#
@@ -118,7 +118,7 @@ petabProblem = createPEtabODEProblem(petabModel,
                                      sensealg=:ForwardDiff, 
                                      reuseS=true)
 
-fvals, xvals = callibrateModel(petabProblem, Fides(verbose=false), 
+fvals, xvals = calibrateModel(petabProblem, Fides(verbose=false), 
                                nOptimisationStarts=5, 
                                samplingMethod=QuasiMonteCarlo.LatinHypercubeSample(), 
                                options=py"{'maxiter' : 200}"o)

--- a/ext/ParameterEstimationExtension.jl
+++ b/ext/ParameterEstimationExtension.jl
@@ -17,6 +17,6 @@ include(joinpath(@__DIR__, "ParameterEstimationExtension", "Optimization", "Setu
 include(joinpath(@__DIR__, "ParameterEstimationExtension", "Optimization", "Callibration.jl"))
 include(joinpath(@__DIR__, "ParameterEstimationExtension", "PEtab_select", "PEtab_select.jl"))
 
-export createOptimProblem, createFidesProblem, callibrateModel, remakePEtabProblem, Fides, runPEtabSelect
+export createOptimProblem, createFidesProblem, calibrateModel, remakePEtabProblem, Fides, runPEtabSelect
 
 end

--- a/ext/ParameterEstimationExtension/Optimization/Callibration.jl
+++ b/ext/ParameterEstimationExtension/Optimization/Callibration.jl
@@ -1,4 +1,4 @@
-function PEtab.callibrateModel(petabProblem::PEtabODEProblem,
+function PEtab.calibrateModel(petabProblem::PEtabODEProblem,
                                optimizer::Union{Optim.LBFGS, Optim.BFGS, Optim.IPNewton};
                                nOptimisationStarts=100,
                                seed=123,
@@ -42,7 +42,7 @@ function PEtab.callibrateModel(petabProblem::PEtabODEProblem,
 
     return objValues, parameterValues
 end
-function PEtab.callibrateModel(petabProblem::PEtabODEProblem,
+function PEtab.calibrateModel(petabProblem::PEtabODEProblem,
                                optimizer::Fides=Fides(verbose=false);
                                nOptimisationStarts=100,
                                seed=123,

--- a/ext/ParameterEstimationExtension/PEtab_select/PEtab_select.jl
+++ b/ext/ParameterEstimationExtension/PEtab_select/PEtab_select.jl
@@ -87,15 +87,15 @@ function PEtab.runPEtabSelect(pathYAML::String,
     """
 
 
-    function _callibrate_model(model, select_problem, _petabProblem::PEtabODEProblem; nOptimisationStarts=nOptimisationStarts)
+    function _calibrate_model(model, select_problem, _petabProblem::PEtabODEProblem; nOptimisationStarts=nOptimisationStarts)
         subspaceId, subspaceYAML, _subspaceParameters = py"get_model_to_test_info"(model)
         subspaceParameters = Dict(Symbol(k) => v for (k, v) in pairs(_subspaceParameters))
         @info "Callibrating model $subspaceId"
         petabProblem = remakePEtabProblem(_petabProblem, subspaceParameters)
         if isnothing(optimizerOptions)
-            _f, _fArg = callibrateModel(petabProblem, optimizer, nOptimisationStarts=nOptimisationStarts, samplingMethod=optimizationSamplingMethod)
+            _f, _fArg = calibrateModel(petabProblem, optimizer, nOptimisationStarts=nOptimisationStarts, samplingMethod=optimizationSamplingMethod)
         else
-            _f, _fArg = callibrateModel(petabProblem, optimizer, nOptimisationStarts=nOptimisationStarts, options=optimizerOptions, samplingMethod=optimizationSamplingMethod)
+            _f, _fArg = calibrateModel(petabProblem, optimizer, nOptimisationStarts=nOptimisationStarts, options=optimizerOptions, samplingMethod=optimizationSamplingMethod)
         end
         whichMin = argmin(_f)
         f = _f[whichMin]
@@ -108,9 +108,9 @@ function PEtab.runPEtabSelect(pathYAML::String,
     end
 
 
-    function callibrate_candidate_models(candidate_space, select_problem, n_candidates, _petabProblem::PEtabODEProblem; nOptimisationStarts=100)
+    function calibrate_candidate_models(candidate_space, select_problem, n_candidates, _petabProblem::PEtabODEProblem; nOptimisationStarts=100)
         for i in 1:n_candidates
-            _callibrate_model(candidate_space.models[i], select_problem, _petabProblem::PEtabODEProblem, nOptimisationStarts=nOptimisationStarts)
+            _calibrate_model(candidate_space.models[i], select_problem, _petabProblem::PEtabODEProblem, nOptimisationStarts=nOptimisationStarts)
         end
     end
 
@@ -155,7 +155,7 @@ function PEtab.runPEtabSelect(pathYAML::String,
         # Start the iterative model selction process
         k == 1 && @info "Model selection round $k with $n_candidates candidates - as the code compiles in this round compiled it takes extra long time https://xkcd.com/303/"
         k != 1 && @info "Model selection round $k with $n_candidates candidates"
-        callibrate_candidate_models(candidate_space, select_problem, n_candidates, _petabProblem, nOptimisationStarts=nOptimisationStarts)
+        calibrate_candidate_models(candidate_space, select_problem, n_candidates, _petabProblem, nOptimisationStarts=nOptimisationStarts)
         newly_calibrated_models, calibrated_models = py"update_selection"(newly_calibrated_models, calibrated_models, select_problem,  candidate_space)
 
         py"update_candidate_space"(candidate_space, select_problem, newly_calibrated_models)

--- a/src/PEtab.jl
+++ b/src/PEtab.jl
@@ -118,7 +118,7 @@ Perform multi-start local optimization for a given PEtabODEProblem and return (f
 - `samplingMethod`: Method for generating start guesses. Any method from QuasiMonteCarlo.jl is supported, with LatinHypercube as the default.
 - `options`: Optimization options. For Optim.jl optimizers, it accepts an `Optim.Options` struct. For Fides, please refer to the Fides documentation and the PEtab.jl documentation for information on setting options.
 """
-function callibrateModel end
+function calibrateModel end
 """
     runPEtabSelect(pathYAML, optimizer; <keyword arguments>)
 
@@ -131,7 +131,7 @@ optimization. Three optimizers are supported: `optimizer=Fides()` (Fides Newton-
 from Optim.jl, and `optimizer=LBFGS()` from Optim.jl. Additional keywords for the optimisation are
 `nOptimisationStarts::Int`- number of multi-starts for parameter estimation (defaults to 100) and
 `optimizationSamplingMethod` - which is any sampling method from QuasiMonteCarlo.jl for generating start guesses
-(defaults to LatinHypercubeSample). See also (add callibrate model)
+(defaults to LatinHypercubeSample). See also (add calibrate model)
 
 Simulation options can be set using any keyword argument accepted by the `createPEtabODEProblem` function.
 For example, setting `gradientMethod=:ForwardDiff` specifies the use of forward-mode automatic differentiation for
@@ -149,7 +149,7 @@ if !isdefined(Base, :get_extension)
 end
 
 
-export createOptimProblem, createFidesProblem, callibrateModel, runPEtabSelect
+export createOptimProblem, createFidesProblem, calibrateModel, runPEtabSelect
 
 
 end

--- a/test/Test_model3/Julia_model_files/Test_model3_callbacks.jl
+++ b/test/Test_model3/Julia_model_files/Test_model3_callbacks.jl
@@ -1,8 +1,0 @@
-function getCallbacks_Test_model3()
-	return CallbackSet(), Function[], false
-end
-
-
-function computeTstops(u::AbstractVector, p::AbstractVector)
-	 return Float64[]
-end


### PR DESCRIPTION
(the former being the correct spelling)

Feels passive-aggressive, but in certain places (I think only in docs) `calibrateModel` was used, which caused some problems. So I was going to make a PR to fix these, and figured that I might as well suggest a full rename (if you prefer to keep it I will revert to just changing instances fo "calibrate" to "callibrate".

Also, the general Julia style standard suggests using lowercase only for functions, and only using capital letters for module and type names (https://docs.julialang.org/en/v1/manual/style-guide/#Use-naming-conventions-consistent-with-Julia-base/). Here, `calibrateModel` suggests you are calling the constructor for a type "`calibrateModel`", rather than a function returning some other output. You are generally going for camel cases, so might make sense to be consistent with that, but I would at least consider exporting `calibrate_model` and similar for the functions that a user might call.
(sorry for commenting on code, but figured I'd at least point it out!)

