### PR TITLE
Allow user to provide the model as ODESystem

### DIFF
--- a/ext/CatalystExtension.jl
+++ b/ext/CatalystExtension.jl
@@ -14,6 +14,6 @@ import PEtab.get_obs_sd_parameter
 RuntimeGeneratedFunctions.init(@__MODULE__)
 
 # For Optimization and model selection
-include(joinpath(@__DIR__, "CatalystExtension", "Read_PEtabModel.jl"))
+include(joinpath(@__DIR__, "CatalystExtension", "Create_PEtab_model.jl"))
 
 end

--- a/ext/CatalystExtension/Create_PEtab_model.jl
+++ b/ext/CatalystExtension/Create_PEtab_model.jl
@@ -1,0 +1,29 @@
+function PEtab.PEtabModel(system::ReactionSystem,
+                          simulation_conditions::Dict{String, T},
+                          observables::Dict{String, PEtab.PEtabObservable},
+                          measurements::DataFrame,
+                          petab_parameters::Vector{PEtab.PEtabParameter};
+                          state_map::Union{Nothing, Vector{Pair{T1, Float64}}}=nothing,
+                          parameter_map::Union{Nothing, Vector{Pair{T2, Float64}}}=nothing,
+                          verbose::Bool=false)::PEtab.PEtabModel where {T1<:Union{Symbol, Num}, T2<:Union{Symbol, Num}, T<:Dict}
+
+    model_name = "ReactionSystemModel"                          
+    return PEtab._PEtabModel(system, model_name, simulation_conditions, observables, measurements, 
+                             petab_parameters, state_map, parameter_map, verbose)
+end
+
+
+function PEtab.get_default_values(system::ReactionSystem)
+    return Catalyst.get_defaults(system)
+end
+
+
+function PEtab.add_parameter_inital_values!(system::ReactionSystem, state_map)
+    return nothing
+end
+
+
+function PEtab.add_model_parameter!(system::ReactionSystem, new_parameter)
+    eval(Meta.parse("@parameters " * new_parameter))
+    Catalyst.addparam!(system, eval(Meta.parse(new_parameter)))
+end

--- a/src/Create_PEtabODEProblem/Create_PEtab_ODEProblem.jl
+++ b/src/Create_PEtabODEProblem/Create_PEtab_ODEProblem.jl
@@ -113,7 +113,7 @@ function PEtabODEProblem(petab_model::PEtabModel;
     timeTake = @elapsed begin
     # Set model parameter values to those in the PeTab parameter to ensure correct constant parameters
     set_parameters_to_file_values!(petab_model.parameter_map, petab_model.state_map, parameter_info)
-    if petab_model.system isa ODESystem
+    if petab_model.system isa ODESystem && petab_model.defined_in_julia == false
         __ode_problem = ODEProblem{true, specialize_level}(petab_model.system, petab_model.state_map, [0.0, 5e3], petab_model.parameter_map, jac=true, sparse=_sparse_jacobian)
     else
         # For reaction systems this bugs out if I try to set specialize_level (specifially state-map and parameter-map are not 

--- a/src/Create_PEtab_model.jl
+++ b/src/Create_PEtab_model.jl
@@ -178,7 +178,8 @@ function PEtabModel(path_yaml::String;
                              path_SBML,
                              path_yaml,
                              cbset,
-                             check_cb_active)
+                             check_cb_active, 
+                             false)
 
     return petab_model
 end

--- a/src/PEtab.jl
+++ b/src/PEtab.jl
@@ -74,6 +74,7 @@ include(joinpath("Create_PEtabODEProblem", "Create_PEtab_ODEProblem.jl"))
 
 # Creating the PEtab model
 include("Create_PEtab_model.jl")
+include(joinpath("Process_PEtab_files", "Julia_tables_provided", "Create_PEtab_model.jl"))
 
 # Importing SBML models
 include(joinpath("SBML", "SBML_to_ModellingToolkit.jl"))

--- a/src/PEtab_structs.jl
+++ b/src/PEtab_structs.jl
@@ -77,6 +77,7 @@ struct PEtabModel{F1<:Function,
     path_yaml::String
     model_callbacks::C
     check_callback_is_active::FA
+    defined_in_julia::Bool
 end
 
 

--- a/src/Process_PEtab_files/Observables/Common.jl
+++ b/src/Process_PEtab_files/Observables/Common.jl
@@ -45,12 +45,12 @@ end
 """
     get_word(str::String, i_start::Int, char_terminate::Vector{Char})
 
-    In a string starting from position i_start extract the next "word", which is the longest
-    concurent occurance of characters that are not in the character list with word termination
-    characters. Returns the word and i_end (the position where the word ends).
+In a string starting from position i_start extract the next "word", which is the longest
+concurent occurance of characters that are not in the character list with word termination
+characters. Returns the word and i_end (the position where the word ends).
 
-    For example, if charListTerm = ['(', ')', '+', '-', '/', '*', '^'] abc123 is
-    considered a word but not abc123*.
+For example, if char_terminate = ['(', ')', '+', '-', '/', '*', '^'] abc123 is
+considered a word but not abc123*.
 """
 function get_word(str::String, i_start::Int, char_terminate::Vector{Char})
 

--- a/test/Julia_import/Case001.jl
+++ b/test/Julia_import/Case001.jl
@@ -1,0 +1,56 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    @parameters a0 b0
+    @species A(t)=a0 B(t)=b0
+    (k1, k2), A <--> B
+end
+
+@parameters a0 b0 k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs; defaults=Dict(A => a0, B => b0))
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0"],
+                         obs_id=["obs_a", "obs_a"],
+                         time=[0, 10.0],
+                         measurement=[0.7, 0.1],
+                         noise_parameters=0.5)
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict())
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:a0, value=1.0, scale=:lin),
+                    PEtabParameter(:b0, value=0.0, scale=:lin),
+                    PEtabParameter(:k1, value=0.8, scale=:lin),
+                    PEtabParameter(:k2, value=0.6, scale=:lin)]
+
+# Observable equation                     
+@unpack A = rn
+observables = Dict("obs_a" => PEtabObservable(A, 0.5))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 0.84750169713188 atol=1e-3
+@test nll_sys ≈ 0.84750169713188 atol=1e-3

--- a/test/Julia_import/Case002.jl
+++ b/test/Julia_import/Case002.jl
@@ -1,0 +1,56 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    @parameters a0
+    @species A(t)=a0
+    (k1, k2), A <--> B
+end
+
+@parameters a0 k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs; defaults=Dict(A => a0))
+
+state_map = [:B => 1.0] # Constant initial value for B 
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0", "c1", "c1"],
+                         obs_id=["obs_a", "obs_a", "obs_a", "obs_a"],
+                         time=[0, 10.0, 0, 10.0],
+                         measurement=[0.7, 0.1, 0.8, 0.2])
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict(:a0 => 0.8), 
+                             "c1" => Dict(:a0 => 0.9))
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:k1, value=0.8, scale=:lin),
+                    PEtabParameter(:k2, value=0.6, scale=:lin)]
+
+# Observable equation                     
+@unpack A = rn
+observables = Dict("obs_a" => PEtabObservable(A, 1.0))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                            petab_parameters, verbose=false, state_map=state_map)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false, state_map=state_map)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 4.09983582520606 atol=1e-3
+@test nll_sys ≈ 4.09983582520606 atol=1e-3

--- a/test/Julia_import/Case003.jl
+++ b/test/Julia_import/Case003.jl
@@ -1,0 +1,57 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    @parameters a0 b0
+    @species A(t)=a0 B(t)=b0
+    (k1, k2), A <--> B
+end
+
+@parameters a0 b0 k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs; defaults=Dict(A => a0, B => b0))
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0"],
+                         obs_id=["obs_a", "obs_a"],
+                         time=[0, 10.0],
+                         measurement=[0.7, 0.1],
+                         observable_parameters=["0.5;2", "0.5;2"])
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict())
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:a0, value=1.0, scale=:lin),
+                    PEtabParameter(:b0, value=0.0, scale=:lin),
+                    PEtabParameter(:k1, value=0.8, scale=:lin),
+                    PEtabParameter(:k2, value=0.6, scale=:lin)]
+
+# Observable equation                     
+@unpack A = rn
+@parameters observableParameter1_obs_a observableParameter2_obs_a
+observables = Dict("obs_a" => PEtabObservable(observableParameter1_obs_a * A + observableParameter2_obs_a, 0.5))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 15.87199287779978 atol=1e-3
+@test nll_sys ≈ 15.87199287779978 atol=1e-3

--- a/test/Julia_import/Case004.jl
+++ b/test/Julia_import/Case004.jl
@@ -1,0 +1,59 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    @parameters a0 b0
+    @species A(t)=a0 B(t)=b0
+    (k1, k2), A <--> B
+end
+
+@parameters a0 b0 k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs; defaults=Dict(A => a0, B => b0))
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0"],
+                         obs_id=["obs_a", "obs_a"],
+                         time=[0, 10.0],
+                         measurement=[0.7, 0.1],
+                         observable_parameters=["0.5;2", "0.5;2"])
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict())
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:a0, value=1.0, scale=:lin),
+                    PEtabParameter(:b0, value=0.0, scale=:lin),
+                    PEtabParameter(:k1, value=0.8, scale=:lin),
+                    PEtabParameter(:k2, value=0.6, scale=:lin), 
+                    PEtabParameter(:scaling_A, value=0.5, scale=:lin),
+                    PEtabParameter(:offset_A, value=2.0, scale=:lin)]
+
+# Observable equation                     
+@unpack A = rn
+@parameters scaling_A offset_A
+observables = Dict("obs_a" => PEtabObservable(scaling_A * A + offset_A, 1.0))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 5.69297960953693 atol=1e-3
+@test nll_sys ≈ 5.69297960953693 atol=1e-3

--- a/test/Julia_import/Case006.jl
+++ b/test/Julia_import/Case006.jl
@@ -1,0 +1,57 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    @parameters a0 b0
+    @species A(t)=a0 B(t)=b0
+    (k1, k2), A <--> B
+end
+
+@parameters a0 b0 k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs; defaults=Dict(A => a0, B => b0))
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0"],
+                         obs_id=["obs_a", "obs_a"],
+                         time=[0.0, 10.0],
+                         measurement=[0.7, 0.1], 
+                         observable_parameters=[10.0, 15.0])
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict())
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:a0, value=1.0, scale=:lin),
+                    PEtabParameter(:b0, value=0.0, scale=:lin),
+                    PEtabParameter(:k1, value=0.8, scale=:lin),
+                    PEtabParameter(:k2, value=0.6, scale=:lin)]
+
+# Observable equation                     
+@unpack A = rn
+@parameters observableParameter1_obs_a
+observables = Dict("obs_a" => PEtabObservable(observableParameter1_obs_a * A, 1.0))                    
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                            petab_parameters, verbose=false)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 65.10833033589059 atol=1e-3
+@test nll_sys ≈ 65.10833033589059 atol=1e-3

--- a/test/Julia_import/Case007.jl
+++ b/test/Julia_import/Case007.jl
@@ -1,0 +1,56 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    @parameters a0 b0 offset_A
+    @species A(t)=a0 B(t)=b0
+    (k1, k2), A <--> B
+end
+
+@parameters a0 b0 k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs; defaults=Dict(A => a0, B => b0))
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0"],
+                         obs_id=["obs_a", "obs_b"],
+                         time=[10.0, 10.0],
+                         measurement=[0.2, 0.8])
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict())
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:a0, value=1.0, scale=:lin),
+                    PEtabParameter(:b0, value=0.0, scale=:lin),
+                    PEtabParameter(:k1, value=0.8, scale=:lin),
+                    PEtabParameter(:k2, value=0.6, scale=:lin)]
+
+# Observable equation                     
+@unpack A, B = rn
+observables = Dict("obs_a" => PEtabObservable(A, 0.5), 
+                   "obs_b" => PEtabObservable(B, 0.6, transformation=:log10))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 1.378941036858 atol=1e-3
+@test nll_sys ≈ 1.378941036858 atol=1e-3

--- a/test/Julia_import/Case008.jl
+++ b/test/Julia_import/Case008.jl
@@ -1,0 +1,55 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    @parameters a0 b0
+    @species A(t)=a0 B(t)=b0
+    (k1, k2), A <--> B
+end
+
+@parameters a0 b0 k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs; defaults=Dict(A => a0, B => b0))
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0", "c0"],
+                         obs_id=["obs_a", "obs_a", "obs_a"],
+                         time=[0.0, 10.0, 10.0],
+                         measurement=[0.7, 0.1, 0.2])
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict())
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:a0, value=1.0, scale=:lin),
+                    PEtabParameter(:b0, value=0.0, scale=:lin),
+                    PEtabParameter(:k1, value=0.8, scale=:lin),
+                    PEtabParameter(:k2, value=0.6, scale=:lin)]
+
+# Observable equation                     
+@unpack A = rn
+observables = Dict("obs_a" => PEtabObservable(A, 0.5))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 1.17778328012676 atol=1e-3
+@test nll_sys ≈ 1.17778328012676 atol=1e-3

--- a/test/Julia_import/Case009.jl
+++ b/test/Julia_import/Case009.jl
@@ -1,0 +1,56 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    @parameters a0 b0
+    @species A(t)=a0 B(t)=b0
+    (k1, k2), A <--> B
+end
+
+@parameters a0 b0 k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs; defaults=Dict(A => a0, B => b0))
+
+# Measurement data 
+measurements = DataFrame(pre_eq_id=["preeq_c0", "preeq_c0"],
+                         simulation_id=["c0", "c0"],
+                         obs_id=["obs_a", "obs_a"],
+                         time=[1.0, 10.0],
+                         measurement=[0.7, 0.1])
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict(:k1 => 0.8), 
+                               "preeq_c0" => Dict(:k1 => 0.3))
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:a0, value=1.0, scale=:lin),
+                    PEtabParameter(:b0, value=0.0, scale=:lin),
+                    PEtabParameter(:k2, value=0.6, scale=:lin)]
+
+# Observable equation                     
+@unpack A = rn
+observables = Dict("obs_a" => PEtabObservable(A, 0.5))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 0.75799668259765 atol=1e-3
+@test nll_sys ≈ 0.75799668259765 atol=1e-3

--- a/test/Julia_import/Case010.jl
+++ b/test/Julia_import/Case010.jl
@@ -1,0 +1,55 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model
+rn = @reaction_network begin
+    (k1, k2), A <--> B
+end
+
+@parameters k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs)
+
+state_map = [:A => 1.0]
+
+# Measurement data
+measurements = DataFrame(pre_eq_id=["preeq_c0", "preeq_c0"],
+                         simulation_id=["c0", "c0"],
+                         obs_id=["obs_a", "obs_a"],
+                         time=[1.0, 10.0],
+                         measurement=[0.7, 0.1])
+
+# Single experimental condition
+simulation_conditions = Dict("c0" => Dict(:k1 => 0.8, :B => 1.0),
+                             "preeq_c0" => Dict(:k1 => 0.3, :B => 0.0))
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:k2, value=0.6, scale=:lin)]
+
+# Observable equation
+@unpack A = rn
+observables = Dict("obs_a" => PEtabObservable(A, :lin, 0.5))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false, state_map=state_map)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false, state_map=state_map)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 1.20628941926143 atol=1e-3
+@test nll_sys ≈ 1.20628941926143 atol=1e-3
+

--- a/test/Julia_import/Case011.jl
+++ b/test/Julia_import/Case011.jl
@@ -1,0 +1,53 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    (k1, k2), A <--> B
+end
+
+@parameters k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs)
+
+state_map = [:A => 1.0]
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0"],
+                         obs_id=["obs_a", "obs_a"],
+                         time=[0.0, 10.0],
+                         measurement=[0.7, 0.1])
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict(:B => 2.0))
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:k1, value=0.8, scale=:lin)
+                    PEtabParameter(:k2, value=0.6, scale=:lin)]
+
+# Observable equation                     
+@unpack A = rn
+observables = Dict("obs_a" => PEtabObservable(A, 0.5))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                            petab_parameters, verbose=false, state_map=state_map)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false, state_map=state_map)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 3.44341831317718 atol=1e-3
+@test nll_sys ≈ 3.44341831317718 atol=1e-3

--- a/test/Julia_import/Case013.jl
+++ b/test/Julia_import/Case013.jl
@@ -1,0 +1,41 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration. 
+    Test not applicable for ODE-system (unless an additional parameter would 
+    be added). Also, in real life set B=>par as default
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    @parameters par
+    (k1, k2), A <--> B
+end
+state_map = [:A => 1.0]
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0"],
+                         obs_id=["obs_a", "obs_a"],
+                         time=[0.0, 10.0],
+                         measurement=[0.7, 0.1])
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict(:B => :par))
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:k1, value=0.8, scale=:lin),
+                    PEtabParameter(:k2, value=0.6, scale=:lin), 
+                    PEtabParameter(:par, value=7.0, scale=:lin)]
+
+# Observable equation                     
+@unpack A = rn
+observables = Dict("obs_a" => PEtabObservable(A, 0.5))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false, state_map=state_map)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+@test nll_rn ≈ 22.79033132827511 atol=1e-3

--- a/test/Julia_import/Case014.jl
+++ b/test/Julia_import/Case014.jl
@@ -1,0 +1,57 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    @parameters a0 b0
+    @species A(t)=a0 B(t)=b0
+    (k1, k2), A <--> B
+end
+
+@parameters a0 b0 k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs; defaults=Dict(A => a0, B => b0))
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0"],
+                         obs_id=["obs_a", "obs_a"],
+                         time=[0.0, 10.0],
+                         measurement=[0.7, 0.1], 
+                         noise_parameters=["0.5;2.0", "0.5;2.0"])
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict())
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:k1, value=0.8, scale=:lin),
+                    PEtabParameter(:k2, value=0.6, scale=:lin), 
+                    PEtabParameter(:a0, value=1.0, scale=:lin), 
+                    PEtabParameter(:b0, value=0.0, scale=:lin)]
+
+# Observable equation                     
+@unpack A = rn
+@parameters noiseParameter1_obs_a noiseParameter2_obs_a
+observables = Dict("obs_a" => PEtabObservable(A, noiseParameter1_obs_a + noiseParameter2_obs_a))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                            petab_parameters, verbose=false)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 3.68629528983135 atol=1e-3
+@test nll_sys ≈ 3.68629528983135 atol=1e-3

--- a/test/Julia_import/Case015.jl
+++ b/test/Julia_import/Case015.jl
@@ -1,0 +1,58 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    @parameters a0 b0
+    @species A(t)=a0 B(t)=b0
+    (k1, k2), A <--> B
+end
+
+@parameters a0 b0 k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs; defaults=Dict(A => a0, B => b0))
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0"],
+                         obs_id=["obs_a", "obs_a"],
+                         time=[0.0, 10.0],
+                         measurement=[0.7, 0.1], 
+                         noise_parameters=["noise", "noise"])
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict())
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:k1, value=0.8, scale=:lin),
+                    PEtabParameter(:k2, value=0.6, scale=:lin), 
+                    PEtabParameter(:a0, value=1.0, scale=:lin), 
+                    PEtabParameter(:b0, value=0.0, scale=:lin), 
+                    PEtabParameter(:noise, value=5.0, scale=:lin)]
+
+# Observable equation                     
+@unpack A = rn
+@parameters noiseParameter1_obs_a
+observables = Dict("obs_a" => PEtabObservable(A, noiseParameter1_obs_a))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 5.06071208119597 atol=1e-3
+@test nll_sys ≈ 5.06071208119597 atol=1e-3

--- a/test/Julia_import/Case016.jl
+++ b/test/Julia_import/Case016.jl
@@ -1,0 +1,56 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    @parameters a0 b0
+    @species A(t)=a0 B(t)=b0
+    (k1, k2), A <--> B
+end
+
+@parameters a0 b0 k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs; defaults=Dict(A => a0, B => b0))
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0"],
+                         obs_id=["obs_a", "obs_b"],
+                         time=[10.0, 10.0],
+                         measurement=[0.2, 0.8])
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict())
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:k1, value=0.8, scale=:lin),
+                    PEtabParameter(:k2, value=0.6, scale=:lin), 
+                    PEtabParameter(:a0, value=1.0, scale=:lin), 
+                    PEtabParameter(:b0, value=0.0, scale=:lin)]
+
+# Observable equation                     
+@unpack A, B = rn
+observables = Dict("obs_a" => PEtabObservable(A, 0.5),
+                   "obs_b" => PEtabObservable(B, 0.7, transformation=:log))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                            petab_parameters, verbose=false)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 0.78492623889606 atol=1e-3
+@test nll_sys ≈ 0.78492623889606 atol=1e-3

--- a/test/Julia_import/Case017.jl
+++ b/test/Julia_import/Case017.jl
@@ -1,0 +1,52 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    (k1, k2), A <--> B
+end
+
+@parameters k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs)
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0"],
+                         pre_eq_id = ["preeq_c0", "preeq_c0"],
+                         obs_id=["obs_a", "obs_a"],
+                         time=[1.0, 10.0],
+                         measurement=[0.7, 0.1])
+
+# Single experimental condition                          
+simulation_conditions = Dict("preeq_c0" => Dict(:k1 => 0.3, :A => 0.0, :B => 2.0), 
+                             "c0" => Dict(:k1 => 0.8, :A => 1.0, :B => NaN))
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:k2, value=0.6, scale=:lin)]
+
+# Observable equation                     
+@unpack A = rn
+observables = Dict("obs_a" => PEtabObservable(A, 0.5))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                            petab_parameters, verbose=false)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 1.22063957624351 atol=1e-3
+@test nll_sys ≈ 1.22063957624351 atol=1e-3

--- a/test/Julia_import/Case018.jl
+++ b/test/Julia_import/Case018.jl
@@ -1,0 +1,53 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    (k1, k2), A <--> B
+end
+
+@parameters k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs)
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0", "c0", "c0"],
+                         pre_eq_id = ["preeq_c0", "preeq_c0", "preeq_c0", "preeq_c0"],
+                         obs_id=["obs_a", "obs_a", "obs_a", "obs_b"],
+                         time=[0.0, 1.0, 10.0, 0.0],
+                         measurement=[0.1, 0.7, 0.1, 0.1])
+
+# Single experimental condition                          
+simulation_conditions = Dict("preeq_c0" => Dict(:k1 => 0.3, :A => 0.0, :B => 2.0), 
+                             "c0" => Dict(:k1 => 0.8, :A => 1.0, :B => NaN))
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:k2, value=0.6, scale=:lin)]
+
+# Observable equation                     
+@unpack A, B = rn
+observables = Dict("obs_a" => PEtabObservable(A, 0.5), 
+                   "obs_b" => PEtabObservable(B, 0.2))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 6.3898204385477 atol=1e-3
+@test nll_sys ≈ 6.3898204385477 atol=1e-3

--- a/test/Julia_import/Example.jl
+++ b/test/Julia_import/Example.jl
@@ -1,0 +1,124 @@
+#=
+    Showing all different things we can handle with PEtab.jl
+=#
+
+using CSV
+using Catalyst
+using DataFrames
+using Distributions
+using PEtab
+
+
+rn = @reaction_network begin
+    @parameters se0
+    @species SE(t) = se0  # se0 = initial value for S
+    c1, S + E --> SE
+    c2, SE --> S + E
+    c3, SE --> P + E
+end
+
+@parameters c1, c2, c3, se0
+@variables t S(t) SE(t) P(t) E(t)
+D = Differential(t)
+eqs = [
+    D(S) ~ -c1*S*E + c2*SE, 
+    D(E) ~ -c1*S*E + c2*SE + c3*SE, 
+    D(SE) ~ c1*S*E - c2*SE - c3*SE, 
+    D(P) ~ c3*SE
+]
+@named system = ODESystem(eqs; defaults=Dict(SE => se0))
+
+#=
+Set a constant state (in this case E and P) and parameter (in this case c1)
+values via a state- and parameter-map respectively with a vector on the form
+Symbol(variable) => value
+=#
+state_map =  [:E => 1.0, :P => 0.0]
+parameter_map = [:c1 => 1.0]
+
+#=
+For each simulation condtion we can specify values for states (in this case S)
+and/or model parameters (in this case :c2) via a Dict. For these controll-
+parameters values must be set for each simulation condition. Note - c0_pre corresponds
+to a pre-equilibration - which is a steady-state simulation carried out prior to
+matching the model against data (to mimic that cells are at steady-state at time zero).
+=#
+simulation_conditions = Dict("c0_pre" => Dict(:S => 2.0, :c2 => 2.0),
+                             "c0" => Dict(:S => 10.0, :c2 => 2.0))
+
+#=
+A PEtabObservable has fields;
+    observable formula : (formula for what is observed, e.g S + S)
+    measurment noise distribution . (either :lin (normal) or log-normal (:log))
+    noise-formula : formula for measurement noise σ
+
+Parameters on the form noiseParameter... maps to the parameter or values specifed
+under noise_parameter in the measurement data, and parameters on the form
+observableParameter... maps to the parameters or values specifed in the
+observable_parameters column in the measurement data. This allows the user to
+specify different, for example, noise parameters per measurement to mimic a setting
+where the same observable (e.g S) might been observed in different experiments, or
+with different assays.
+=#
+@unpack S, P = rn
+@parameters noiseParameter1_obs_S observableParameter1_obs_P observableParameter2_obs_P
+observables = Dict("obs_S" => PEtabObservable(S, noiseParameter1_obs_S * S, transformation=:log),
+                   "obs_P" => PEtabObservable(observableParameter1_obs_P*P + observableParameter2_obs_P, 1.0))
+
+#=
+The column pre_eq_id corresponds to the pre-equilibration criteria, that is under which
+simulation-condition setting to carry out a steady-state simulation prior to matching the
+model against data (e.g to mimic that cells are at steady-state at time zero). The column
+observable_parameters holds the values for the observable-parameters specified in the
+observable formula, and these can be parameters (specified in PEtabParameters) or constant
+values (e.g 1.0). In case of several values these should be separated by ;. Similiar holds
+for noise_parameter - these map to the noiseParameter... values in the noise-formula, and
+these can be parameters or values. In case there are now noise-parameters, or observable-
+parameters these columns can be left out (they are optional).
+=#
+measurements = DataFrame(simulation_id=["c0", "c0", "c0", "c0"],
+                         pre_eq_id=["c0_pre", "c0_pre", "c0_pre", "c0_pre"], # Steady-state pre-eq simulations
+                         obs_id=["obs_S", "obs_S", "obs_P", "obs_P"],
+                         time=[0.0, 10.0, 1.0, 20.0],
+                         measurement=[0.7, 0.1, 1.0, 1.5],
+                         observable_parameters=["", "", "scale_P;offset_P", "1.0;1.0"],
+                         noise_parameters=["noise", "1.0", "", ""])
+
+#=
+For a PEtab parameter to estimate the user must specify id. Then the user can choose scale
+to estimate the parameter on (:log10 (default), :lin and :log). For each parameter any
+univariate cont. prior can be set to turn the parameter estimation problem into a
+maximum a posteriori problem. If prior_on_linear_scale=true (default) the prior applies
+on the linear-scale, while if false it applies on the parameter scale (e.g log10 in case
+the user choose scale=:log10). In case the parameter is not be estimated the user can
+set estimate=false (default true). lb and ub (lower and upper bounds) can also be
+set for each parameter.
+=#
+petab_parameters = [PEtabParameter(:c3, scale=:log10, prior=Normal(0.0, 2.0), prior_on_linear_scale=false),
+                    PEtabParameter(:se0, scale=:lin, prior=LogNormal(1.0, 0.5)),
+                    PEtabParameter(:scale_P, scale=:log10),
+                    PEtabParameter(:offset_P, scale=:log10),
+                    PEtabParameter(:noise, scale=:log10)]
+
+# Given all this it is easy to set a PEtabODEProblem and then compute the cost, gradient
+# and Hessian.
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                            petab_parameters, state_map=state_map, parameter_map=parameter_map,
+                            verbose=true)
+petab_problem_rn = PEtabODEProblem(petab_model_rn)
+
+petab_model_ode = PEtabModel(system, simulation_conditions, observables, measurements,
+                             petab_parameters, state_map=state_map, parameter_map=parameter_map,
+                             verbose=true)
+petab_problem_ode = PEtabODEProblem(petab_model_ode)
+
+# Compute negative log-likelihood, gradient and Hessian
+θ = [1.0, 1.0, 1.0, 1.0, 1.0]
+f_rn = petab_problem_rn.compute_cost(θ)
+∇f_rn = petab_problem_rn.compute_gradient(θ)
+Δf_rn = petab_problem_rn.compute_hessian(θ)
+
+f_ode = petab_problem_ode.compute_cost(θ)
+∇f_ode = petab_problem_ode.compute_gradient(θ)
+Δf_ode = petab_problem_ode.compute_hessian(θ)
+

--- a/test/Julia_import/Input_format.jl
+++ b/test/Julia_import/Input_format.jl
@@ -1,0 +1,205 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+
+    # Define reaction network model
+    rn = @reaction_network begin
+        @parameters a0
+        @species A(t)=a0
+        (k1, k2), A <--> B
+    end
+    state_map = [:B => 1.0] # Constant initial value for B
+
+    # Measurement data
+    measurements = DataFrame(simulation_id=["c0", "c0", "c1", "c1"],
+                            obs_id=["obs_a", "obs_a", "obs_a", "obs_a"],
+                            time=[0, 10.0, 0, 10.0],
+                            measurement=[0.7, 0.1, 0.8, 0.2])
+
+    # Single experimental condition
+    simulation_conditions = Dict("c0" => Dict(:a0 => 0.8),
+                                 "c1" => Dict(:a0 => 0.9))
+
+    # Observable equation
+    @unpack A = rn
+    observables = Dict(["obs_a" => PEtabObservable(A, :lin, 1.0)])
+
+
+    @testset "Experimental conditions input" begin
+
+        # PEtab-parameter to "estimate"
+        petab_parameters = [PEtabParameter(:k1, value=0.8, scale=:lin),
+                            PEtabParameter(:k2, value=0.6, scale=:lin)]
+
+        # Case 1 everything should work
+        simulation_conditions = Dict("c0" => Dict(:a0 => 0.8),
+                                    "c1" => Dict(:a0 => 0.9))
+        petab_model = PEtabModel(rn, simulation_conditions, observables, measurements,
+                                    petab_parameters, verbose=false, state_map=state_map)
+        @test typeof(petab_model) <: PEtabModel
+
+
+        simulation_conditions = Dict("c0" => Dict(:b0 => 0.8),
+                                    "c1" => Dict(:b0 => 0.9))
+        @test_throws PEtab.PEtabFormatError begin
+        petab_model = PEtabModel(rn, simulation_conditions, observables, measurements,
+                                    petab_parameters, verbose=false, state_map=state_map)
+        end
+
+
+        # PEtab-parameter to "estimate"
+        petab_parameters = [PEtabParameter(:k1, value=0.8, scale=:lin),
+                            PEtabParameter(:k2, value=0.6, scale=:lin), 
+                            PEtabParameter(:noise, value=0.6, scale=:lin)]
+        simulation_conditions = Dict("c0" => Dict(:a0 => 0.8),
+                                    "c1" => Dict(:a0 => :noise))
+        petab_model = PEtabModel(rn, simulation_conditions, observables, measurements,
+                                    petab_parameters, verbose=false, state_map=state_map)
+        @test typeof(petab_model) <: PEtabModel
+
+
+        simulation_conditions = Dict("c0" => Dict(:a0 => 0.8),
+                                    "c1" => Dict(:a0 => :noise1))
+        @test_throws PEtab.PEtabFormatError begin
+        petab_model = PEtabModel(rn, simulation_conditions, observables, measurements,
+                                    petab_parameters, verbose=false, state_map=state_map)
+        end
+
+
+        simulation_conditions = Dict("c0" => Dict(:a0 => 0.8),
+                                    "c1" => Dict(:k1 => :noise))
+        @test_throws PEtab.PEtabFormatError begin
+        petab_model = PEtabModel(rn, simulation_conditions, observables, measurements,
+                                    petab_parameters, verbose=false, state_map=state_map)
+        end
+    end
+
+
+    @testset "PEtabParameters conditions input" begin
+        simulation_conditions = Dict("c0" => Dict(:a0 => 0.8),
+                                    "c1" => Dict(:a0 => :noise))
+
+        petab_parameters = [PEtabParameter(:k1, value=0.8, scale=:lin),
+                            PEtabParameter(:k2, value=0.6, scale=:lin),
+                            PEtabParameter(:noise, value=0.6, scale=:lin)]
+        petab_model = PEtabModel(rn, simulation_conditions, observables, measurements,
+                                        petab_parameters, verbose=false, state_map=state_map)
+        @test typeof(petab_model) <: PEtabModel
+
+
+        petab_parameters = [PEtabParameter(:k1, value=0.8, scale=:lin),
+                            PEtabParameter(:k2, value=0.6, scale=:lin),
+                            PEtabParameter(:noise, value=0.6, scale=:lin),
+                            PEtabParameter(:k3, value=0.6, scale=:lin)]
+        @test_throws PEtab.PEtabFormatError begin
+        petab_model = PEtabModel(rn, simulation_conditions, observables, measurements,
+                                        petab_parameters, verbose=false, state_map=state_map)
+        end
+
+
+        petab_parameters = [PEtabParameter(:k1, value=0.8, scale=:lin),
+                            PEtabParameter(:k2, value=0.6, scale=:lin),
+                            PEtabParameter(:noise, value=0.6, scale=:lin),
+                            PEtabParameter(:k3, value=0.6, scale=:lin, estimate=false)]
+        petab_model = PEtabModel(rn, simulation_conditions, observables, measurements,
+                                        petab_parameters, verbose=false, state_map=state_map)
+        @test typeof(petab_model) <: PEtabModel
+    end
+
+
+    @testset "Measurement data format" begin
+
+        # Single experimental condition
+        simulation_conditions = Dict("c0" => Dict(:a0 => 0.8),
+                                     "c1" => Dict(:a0 => 0.9))
+
+        # PEtab-parameter to "estimate"
+        petab_parameters = [PEtabParameter(:k1, value=0.8, scale=:lin),
+                            PEtabParameter(:k2, value=0.6, scale=:lin),
+                            PEtabParameter(:noise, value=0.6, scale=:lin),
+                            PEtabParameter(:scale_P, value=1.0, scale=:lin),
+                            PEtabParameter(:offset_P, value=1.0, scale=:lin)]
+
+        # Observable equation
+        @unpack A, B = rn
+        @parameters noiseParameter1_obs_A observableParameter1_obs_B observableParameter2_obs_B
+        observables = Dict(["obs_a" => PEtabObservable(A, :lin, noiseParameter1_obs_A),
+                            "obs_b" => PEtabObservable(observableParameter1_obs_B + observableParameter2_obs_B*B, :lin, 1.0)])
+
+        measurements = DataFrame(simulation_id=["c0", "c0", "c1", "c1"],
+                                obs_id=["obs_a", "obs_a", "obs_b", "obs_b"],
+                                time=[0, 10.0, 0, 10.0],
+                                measurement=[0.7, 0.1, 0.8, 0.2],
+                                observable_parameters=[missing, "", "scale_P;offset_P", "1.0;1.0"],
+                                noise_parameters=[1.0, "noise", missing, missing])                    
+        petab_model = PEtabModel(rn, simulation_conditions, observables, measurements,
+                                    petab_parameters, verbose=false, state_map=state_map)
+        @test typeof(petab_model) <: PEtabModel
+
+        path = joinpath(@__DIR__, "Tmp.csv")
+        CSV.write(path, measurements)
+        dataFromDisk = CSV.read(path, DataFrame)
+        rm(path)
+        petab_model = PEtabModel(rn, simulation_conditions, observables, dataFromDisk,
+                                    petab_parameters, verbose=false, state_map=state_map)
+        @test typeof(petab_model) <: PEtabModel
+
+        # Start messing up the data
+        measurements = DataFrame(simulation_id=["c0", "c0", "c1", "c1"],
+                                obs_id=["obs_a", "obs_a", "obs_b", "obs_b"],
+                                time=[0, 10.0, 0, 10.0],
+                                measurement=[0.7, 0.1, 0.8, "tada"],
+                                observable_parameters=[missing, "", "scale_P;offset_P", "1.0;1.0"],
+                                noise_parameters=[1.0, "noise", missing, missing])
+        @test_throws PEtab.PEtabFormatError begin                         
+        petab_model = PEtabModel(rn, simulation_conditions, observables, measurements,
+                                    petab_parameters, verbose=false, state_map=state_map)
+        end                             
+
+        measurements = DataFrame(simulation_id=[1.0, "c0", "c1", "c1"],
+                                obs_id=["obs_a", "obs_a", "obs_b", "obs_b"],
+                                time=[0, 10.0, 0, 10.0],
+                                measurement=[0.7, 0.1, 0.8, 0.3],
+                                observable_parameters=[missing, "", "scale_P;offset_P", "1.0;1.0"],
+                                noise_parameters=[1.0, "noise", missing, missing])
+        @test_throws PEtab.PEtabFormatError begin                         
+        petab_model = PEtabModel(rn, simulation_conditions, observables, measurements,
+                                    petab_parameters, verbose=false, state_map=state_map)
+        end                             
+
+        measurements = DataFrame(simulation_id=["c0", "c0", "c1", "c1"],
+                                obs_id=["obs_a", "obs_a", "obs_b", "obs_c"],
+                                time=[0, 10.0, 0, 10.0],
+                                measurement=[0.7, 0.1, 0.8, 0.3],
+                                observable_parameters=[missing, "", "scale_P;offset_P", "1.0;1.0"],
+                                noise_parameters=[1.0, "noise", missing, missing])
+        @test_throws PEtab.PEtabFormatError begin                         
+        petab_model = PEtabModel(rn, simulation_conditions, observables, measurements,
+                                    petab_parameters, verbose=false, state_map=state_map)
+        end                             
+
+        measurements = DataFrame(simulation_id=["c0", "c0", "c1", "c1"],
+                                obs_id=["obs_a", "obs_a", "obs_b", "obs_b"],
+                                time=[0, 10.0, 0, 10.0],
+                                measurement=[0.7, 0.1, 0.8, 0.3],
+                                observable_parameters=[missing, "", "scale_P;offset_P", "1.0;1.0"],
+                                noise_parameters=[1.0, "noise1", missing, missing])
+        @test_throws PEtab.PEtabFormatError begin                         
+        petab_model = PEtabModel(rn, simulation_conditions, observables, measurements,
+                                    petab_parameters, verbose=false, state_map=state_map)                             
+        end                             
+
+        measurements = DataFrame(simulation_id=["c0", "c0", "c1", "c1"],
+                                obs_id=["obs_a", "obs_a", "obs_b", "obs_b"],
+                                time=[0, 10.0, 0, 10.0],
+                                measurement=[0.7, 0.1, 0.8, 0.3],
+                                observable_parameters=[missing, "", "scale_P;offset_P1", "1.0;1.0"],
+                                noise_parameters=[1.0, "noise", missing, missing])
+        @test_throws PEtab.PEtabFormatError begin                         
+        petab_model = PEtabModel(rn, simulation_conditions, observables, measurements,
+                                    petab_parameters, verbose=false, state_map=state_map) 
+        end                                   
+    end

--- a/test/Julia_import/Parameter_map.jl
+++ b/test/Julia_import/Parameter_map.jl
@@ -1,0 +1,57 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    @parameters a0 b0
+    @species A(t)=a0 B(t)=b0
+    (k1, k2), A <--> B
+end
+
+@parameters a0 b0 k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs; defaults=Dict(A => a0, B => b0))
+
+parameter_map = [:k2 => 1.6]
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0"],
+                         obs_id=["obs_a", "obs_a"],
+                         time=[0, 10.0],
+                         measurement=[0.7, 0.1],
+                         noise_parameters=0.5)
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict())
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:a0, value=1.0, scale=:lin),
+                    PEtabParameter(:b0, value=0.0, scale=:lin),
+                    PEtabParameter(:k1, value=0.8, scale=:log10)]
+
+# Observable equation                     
+@unpack A = rn
+observables = Dict("obs_a" => PEtabObservable(A, 0.5))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                            petab_parameters, verbose=false, parameter_map=parameter_map)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false, parameter_map=parameter_map)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 1.2738049275398435 atol=1e-3
+@test nll_sys ≈ 1.2738049275398435 atol=1e-3

--- a/test/Julia_import/Priors.jl
+++ b/test/Julia_import/Priors.jl
@@ -1,0 +1,56 @@
+#=
+    Recrating PEtab test-suite for Catalyst integration to robustly test that
+    we support a wide arrange of features for PEtab integration
+=#
+
+
+# Define reaction network model 
+rn = @reaction_network begin
+    @parameters a0 b0
+    @species A(t)=a0 B(t)=b0
+    (k1, k2), A <--> B
+end
+
+@parameters a0 b0 k1 k2
+@variables t A(t) B(t)
+D = Differential(t)
+eqs = [
+    D(A) ~ -k1*A + k2*B
+    D(B) ~ k1*A - k2*B
+]
+@named sys = ODESystem(eqs; defaults=Dict(A => a0, B => b0))
+
+# Measurement data 
+measurements = DataFrame(simulation_id=["c0", "c0"],
+                         obs_id=["obs_a", "obs_a"],
+                         time=[0, 10.0],
+                         measurement=[0.7, 0.1],
+                         noise_parameters=0.5)
+
+# Single experimental condition                          
+simulation_conditions = Dict("c0" => Dict())
+
+# PEtab-parameter to "estimate"
+petab_parameters = [PEtabParameter(:a0, value=1.0, scale=:lin),
+                    PEtabParameter(:b0, value=0.0, scale=:lin),
+                    PEtabParameter(:k1, value=0.8, scale=:log10, prior=Normal(-0.8, 0.2), prior_on_linear_scale=false),
+                    PEtabParameter(:k2, value=0.6, scale=:log10, prior=LogNormal(0.6, 1.0))]
+
+# Observable equation                     
+@unpack A = rn
+observables = Dict("obs_a" => PEtabObservable(A, 0.5))
+
+# Create a PEtabODEProblem ReactionNetwork
+petab_model_rn = PEtabModel(rn, simulation_conditions, observables, measurements,
+                            petab_parameters, verbose=false)
+petab_problem_rn = PEtabODEProblem(petab_model_rn, verbose=false)
+# Create a PEtabODEProblem ODESystem
+petab_model_sys = PEtabModel(sys, simulation_conditions, observables, measurements,
+                             petab_parameters, verbose=false)
+petab_problem_sys = PEtabODEProblem(petab_model_sys, verbose=false)
+
+# Compute negative log-likelihood 
+nll_rn = petab_problem_rn.compute_cost(petab_problem_rn.θ_nominalT)
+nll_sys = petab_problem_sys.compute_cost(petab_problem_sys.θ_nominalT)
+@test nll_rn ≈ 7.361276133152829 atol=1e-3
+@test nll_sys ≈ 7.361276133152829 atol=1e-3

--- a/test/Julia_import/Test_catalyst.jl
+++ b/test/Julia_import/Test_catalyst.jl
@@ -1,0 +1,33 @@
+using Test
+using Distributions
+using PEtab 
+using CSV
+using DataFrames
+using Catalyst
+
+# Case 5 and 12 rely on SBML features and have no direct correspondence to 
+# ODESystem or Catalyst 
+@testset "Catalyst integration" begin
+    include(joinpath(@__DIR__, "Case001.jl"))
+    include(joinpath(@__DIR__, "Case002.jl"))
+    include(joinpath(@__DIR__, "Case003.jl"))
+    include(joinpath(@__DIR__, "Case004.jl"))
+    include(joinpath(@__DIR__, "Case006.jl"))
+    include(joinpath(@__DIR__, "Case007.jl"))
+    include(joinpath(@__DIR__, "Case008.jl"))
+    include(joinpath(@__DIR__, "Case009.jl"))
+    include(joinpath(@__DIR__, "Case010.jl"))
+    include(joinpath(@__DIR__, "Case011.jl"))
+    include(joinpath(@__DIR__, "Case013.jl"))
+    include(joinpath(@__DIR__, "Case014.jl"))
+    include(joinpath(@__DIR__, "Case015.jl"))
+    include(joinpath(@__DIR__, "Case016.jl"))
+    include(joinpath(@__DIR__, "Case017.jl"))
+    include(joinpath(@__DIR__, "Case018.jl"))
+    include(joinpath(@__DIR__, "Parameter_map.jl"))
+    include(joinpath(@__DIR__, "Priors.jl"))
+end
+
+@testset "Testing input format" begin
+    include(joinpath(@__DIR__, "Input_format.jl"))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,7 +32,7 @@ end
 
 
 @safetestset "Catalyst integration" begin
-  include(joinpath(@__DIR__, "Catalyst_PEtab_test_suite", "Test_catalyst.jl"))
+  include(joinpath(@__DIR__, "Julia_import", "Test_catalyst.jl"))
 end
 
 


### PR DESCRIPTION
When adding support for Catalyst almost all information needed to provide the model as an ODESystem was in place. Here the last few fixes, and test to achieve this are added.