### PR TITLE
Function for retrieving a full parameter set from a calibration output

### DIFF
--- a/src/PEtab.jl
+++ b/src/PEtab.jl
@@ -95,7 +95,10 @@ include(joinpath("Show.jl"))
     end
 end
 
-export PEtabModel, PEtabODEProblem, ODESolver, SteadyStateSolver, PEtabModel, PEtabODEProblem, remake_PEtab_problem, Fides, solve_SBML, PEtabOptimisationResult, IpoptOptions, IpoptOptimiser, PEtabParameter, PEtabObservable, PEtabMultistartOptimisationResult, generate_startguesses
+# Temporary file added by Torkel.
+include(joinpath("Utility.jl"))
+
+export PEtabModel, PEtabODEProblem, ODESolver, SteadyStateSolver, PEtabModel, PEtabODEProblem, remake_PEtab_problem, Fides, solve_SBML, PEtabOptimisationResult, IpoptOptions, IpoptOptimiser, PEtabParameter, PEtabObservable, PEtabMultistartOptimisationResult, generate_startguesses, get_best_ps
 
 # These are given as extensions, but their docstrings are availble in the 
 # general documentation 

--- a/src/Utility.jl
+++ b/src/Utility.jl
@@ -1,0 +1,30 @@
+# temporary file.
+
+"""
+    get_best_ps(res, model::PEtabModel; c_id="__c0__", parmap=true)
+
+From a PEtab result and model, retrives a full paraemter set. 
+"""
+function get_best_ps(res, model::PEtabModel; c_id="__c0__", parmap=true)    
+    ps = first.(model.parameter_map)
+    p_vals = last.(model.parameter_map)
+    fitted_ps = DataFrame(petab_model.path_parameters)
+    condition_ps = DataFrame(petab_model.path_conditions)
+
+    # Loops through all parameters.
+    for (p_idx, p) in enumerate(ps)
+        if String(ModelingToolkit.getname(p)) in fitted_ps[!, "parameterId"] # If a fitted parameter.
+            p_idx = findfirst(isequal(String(ModelingToolkit.getname(p))), fitted_ps[:,1])
+            if fitted_ps[p_idx,2] == "lin"
+                p_vals[p_idx] = res.xmin[p_idx]
+            else # If scale is logarithmic, need to reverse.
+                p_vals[p_idx] = 10 ^ res.xmin[p_idx]
+            end
+        elseif String(ModelingToolkit.getname(p)) in names(condition_ps)[2:end] # If a parameter varrying withg simulation conditions.
+            (c_id in condition_ps[:,1]) || error("A condition id was given that could not be found in among the petab model conditions.")
+            c_idx = findfirst(isequal(c_id), condition_ps[:,1])
+            p_vals[p_idx] = condition_ps[c_idx,String(ModelingToolkit.getname(p))]
+        end # If neither, teh value from all_ps should be correct.
+    end
+    return (parmap ? Pair.(ps, p_vals) : p_vals)
+end


### PR DESCRIPTION
A quick utility function I threw together. If you think it might be useful, I am happy to clean it up, add tests and documentation, and put it somewhere sensible. Partial functionality like this might exist already, but couldn't find it.

The idea is that it would be nice to have a function that takes the output of a calibration, and returns a full parameter set that can be used for e.g. simulations. For each parameter, if it has been fitted, its value in the optimum is selected (and automatically rescaled if needed). If it has a default (known) value, that is used. If it carries between different conditions, a condition id is designated to determine which condition to use. At the end, the output can be a map ([:kB => 1.0, :kC => 2.0]) or a vector (`[1.0, 2.0]`).

The implementation may still have bugs.