### PR TITLE
Add ability to extract model parameters for simulation

### DIFF
--- a/docs/src/API_choosen.md
+++ b/docs/src/API_choosen.md
@@ -16,4 +16,6 @@ calibrate_model_multistart
 run_PEtab_select
 solve_SBML
 generate_startguesses
+get_fitted_ps
+get_fitted_u0
 ```

--- a/src/Create_PEtabODEProblem/Create_PEtab_ODEProblem.jl
+++ b/src/Create_PEtabODEProblem/Create_PEtab_ODEProblem.jl
@@ -242,6 +242,7 @@ function PEtabODEProblem(petab_model::PEtabModel;
                                     _ss_solver_gradient,
                                     θ_indices,
                                     simulation_info,
+                                    _ode_problem,
                                     split_over_conditions)
     return petab_problem
 end

--- a/src/Create_PEtabODEProblem/Remake_PEtabODEProblem.jl
+++ b/src/Create_PEtabODEProblem/Remake_PEtabODEProblem.jl
@@ -185,6 +185,7 @@ function remake_PEtab_problem(petab_problem::PEtabODEProblem, parameters_change:
                                     petab_problem.ss_solver_gradient,
                                     petab_problem.θ_indices,
                                     petab_problem.simulation_info,
+                                    petab_problem.ode_problem,
                                     petab_problem.split_over_conditions)
     return _petab_problem
 end

--- a/src/PEtab.jl
+++ b/src/PEtab.jl
@@ -98,7 +98,7 @@ include(joinpath("Show.jl"))
     end
 end
 
-export PEtabModel, PEtabODEProblem, ODESolver, SteadyStateSolver, PEtabModel, PEtabODEProblem, remake_PEtab_problem, Fides, solve_SBML, PEtabOptimisationResult, IpoptOptions, IpoptOptimiser, PEtabParameter, PEtabObservable, PEtabMultistartOptimisationResult, generate_startguesses, get_best_model_parameters
+export PEtabModel, PEtabODEProblem, ODESolver, SteadyStateSolver, PEtabModel, PEtabODEProblem, remake_PEtab_problem, Fides, solve_SBML, PEtabOptimisationResult, IpoptOptions, IpoptOptimiser, PEtabParameter, PEtabObservable, PEtabMultistartOptimisationResult, generate_startguesses, get_fitted_ps, get_fitted_u0
 
 # These are given as extensions, but their docstrings are availble in the 
 # general documentation 

--- a/src/PEtab.jl
+++ b/src/PEtab.jl
@@ -83,6 +83,9 @@ include(joinpath("SBML", "Process_functions.jl"))
 include(joinpath("SBML", "Process_rules.jl"))
 include(joinpath("SBML", "Solve_SBML_model.jl"))
 
+# Nice util functions 
+include(joinpath("Utility.jl"))
+
 # For correct struct printing
 include(joinpath("Show.jl"))
 # Reduce time for reading a PEtabModel and for building a PEtabODEProblem
@@ -95,7 +98,7 @@ include(joinpath("Show.jl"))
     end
 end
 
-export PEtabModel, PEtabODEProblem, ODESolver, SteadyStateSolver, PEtabModel, PEtabODEProblem, remake_PEtab_problem, Fides, solve_SBML, PEtabOptimisationResult, IpoptOptions, IpoptOptimiser, PEtabParameter, PEtabObservable, PEtabMultistartOptimisationResult, generate_startguesses
+export PEtabModel, PEtabODEProblem, ODESolver, SteadyStateSolver, PEtabModel, PEtabODEProblem, remake_PEtab_problem, Fides, solve_SBML, PEtabOptimisationResult, IpoptOptions, IpoptOptimiser, PEtabParameter, PEtabObservable, PEtabMultistartOptimisationResult, generate_startguesses, get_best_model_parameters
 
 # These are given as extensions, but their docstrings are availble in the 
 # general documentation 

--- a/src/PEtab_structs.jl
+++ b/src/PEtab_structs.jl
@@ -300,6 +300,7 @@ struct PEtabODEProblem{F1<:Function,
     ss_solver_gradient::SteadyStateSolver
     θ_indices::ParameterIndices
     simulation_info::SimulationInfo
+    ode_problem::ODEProblem
     split_over_conditions::Bool
 end
 

--- a/src/Utility.jl
+++ b/src/Utility.jl
@@ -1,0 +1,81 @@
+
+"""
+    get_best_model_parameters(res::Union{PEtabOptimisationResult, PEtabMultistartOptimisationResult}, 
+                              petab_problem::PEtabODEProblem,
+                              condition_id::Union{String, Symbol}; 
+                              pre_eq_id::Union{String, Nothing}=nothing, 
+                              retmap=true)
+
+From a PEtab parameter estimation result and model, retrives a full parameter set and intial values 
+to simulate the model.
+"""
+function get_best_model_parameters(res::Union{PEtabOptimisationResult, PEtabMultistartOptimisationResult}, 
+                                   petab_problem::PEtabODEProblem,
+                                   condition_id::Union{String, Symbol}; 
+                                   pre_eq_id::Union{String, Symbol, Nothing}=nothing, 
+                                   retmap=true)
+
+
+    @unpack θ_indices, petab_model, simulation_info, ode_problem = petab_problem
+
+    # Sanity check input
+    _c_id = Symbol(condition_id)
+    @assert _c_id ∈ simulation_info.simulation_condition_id "A simulation condition id was given that could not be found in among the petab model conditions."
+    if !isnothing(pre_eq_id)
+        _pre_eq_id = Symbol(pre_eq_id)
+        @assert _pre_eq_id ∈ simulation_info.pre_equilibration_condition_id "A pre-equilbration simulation condition id was given that could not be found in among the petab model conditions."
+    else
+        _pre_eq_id = nothing
+    end
+
+    p, ps = ode_problem.p, first.(petab_model.parameter_map)
+    u0, u0s = ode_problem.u0, first.(petab_model.state_map)
+
+    θT = transformθ(res.xmin, θ_indices.θ_names, θ_indices)
+    θ_dynamic, θ_observable, θ_sd, θ_non_dynamic = splitθ(θT, θ_indices)
+
+    # Set constant model parameters 
+    change_ode_parameters!(p, u0, θ_dynamic, θ_indices, petab_model)
+
+    # In case of no pre-eq condition we are done after changing to the condition s
+    # Condition specific parameters 
+    if isnothing(pre_eq_id)            
+        _change_simulation_condition!(p, u0, _c_id, θ_dynamic, petab_model, θ_indices)
+        _u0 = retmap ? Pair.(u0s, u0) : u0
+        _p = retmap ? Pair.(ps, p) : p
+        return _u0, _p
+    end
+
+    # For models with pre-eq in order to correctly return the initial values the model 
+    # must first be simulated to steady state, and following the parameters must 
+    # be set correctly
+    u_ss = Vector{Float64}(undef, length(u0)) 
+    u_t0 = Vector{Float64}(undef, length(u0))
+    change_simulation_condition! = (p_ode_problem, u0, conditionId) -> _change_simulation_condition!(p_ode_problem, u0, conditionId, θ_dynamic, petab_model, θ_indices)
+
+    pre_eq_sol = solve_ode_pre_equlibrium!(u_ss,
+                                           u_t0,
+                                           remake(ode_problem, p=p, u0=u0),
+                                           change_simulation_condition!,
+                                           _pre_eq_id,
+                                           petab_problem.ode_solver,
+                                           petab_problem.ss_solver,
+                                           petab_model.convert_tspan)
+
+    change_simulation_condition!(p, u0, _c_id)
+    # Sometimes the experimentaCondition-file changes the initial values for a state
+    # whose value was changed in the preequilibration-simulation. The experimentaCondition
+    # value is prioritized by only changing u0 to the steady state value for those states
+    # that were not affected by change to shift_expid.
+    has_not_changed = u0 .== u_t0
+    u0[has_not_changed] .= u_ss[has_not_changed]
+
+    # According to the PEtab standard we can sometimes have that initial assignment is overridden for
+    # pre-eq simulation, but we do not want to override for main simulation which is done automatically
+    # by change_simulation_condition!. These cases are marked as NaN
+    u0[isnan.(ode_problem.u0)] .= u_ss[isnan.(u0)]
+
+    _u0 = retmap ? Pair.(u0s, u0) : u0
+    _p = retmap ? Pair.(ps, p) : p
+    return _u0, _p
+end

--- a/test/Test_util.jl
+++ b/test/Test_util.jl
@@ -1,0 +1,74 @@
+using Catalyst
+using PEtab
+using OrdinaryDiffEq
+using Test
+
+
+@testset "Extract simulation parameters" begin
+    #=
+    Test ability to retrive model parameters for specific model conditions
+    =#
+    # Model without pre-eq or condition specific parameters
+    path_yaml = joinpath(@__DIR__, "Test_ll", "Boehm_JProteomeRes2014", "Boehm_JProteomeRes2014.yaml")
+    petab_model = PEtabModel(path_yaml, build_julia_files=true, write_to_file=false, verbose=false)
+    petab_problem = PEtabODEProblem(petab_model, verbose=false)
+    θ = petab_problem.θ_nominalT .* 0.9
+    cost = petab_problem.compute_cost(θ)
+    res = PEtabOptimisationResult(:Fides,
+                                  Vector{Vector{Float64}}(undef, 0),
+                                  Vector{Float64}(undef, 0),
+                                  10,
+                                  cost,
+                                  θ ./ 0.9,
+                                  θ,
+                                  true,
+                                  10.0)
+    c_id = :model1_data1
+    @unpack u0, p = petab_problem.simulation_info.ode_sols[c_id].prob
+    u0_test, p_test = get_best_model_parameters(res, petab_problem, c_id; retmap=false)
+    @test all(u0_test .== u0)
+    @test all(p == p_test)
+
+    # Beer model
+    path_yaml = joinpath(@__DIR__, "Test_ll", "Beer_MolBioSystems2014", "Beer_MolBioSystems2014.yaml")
+    petab_model = PEtabModel(path_yaml, verbose=false, build_julia_files=true)
+    petab_problem = PEtabODEProblem(petab_model, verbose=false)
+    θ = petab_problem.θ_nominalT .* 0.9
+    cost = petab_problem.compute_cost(θ)
+    res = PEtabOptimisationResult(:Fides,
+                                  Vector{Vector{Float64}}(undef, 0),
+                                  Vector{Float64}(undef, 0),
+                                  10,
+                                  cost,
+                                  θ ./ 0.9,
+                                  θ,
+                                  true,
+                                  10.0)
+    c_id = :typeIDT1_ExpID1
+    @unpack u0, p = petab_problem.simulation_info.ode_sols[c_id].prob
+    u0_test, p_test = get_best_model_parameters(res, petab_problem, c_id; retmap=false)
+    @test all(u0_test .== u0)
+    @test all(p[2:end] == p_test[2:end]) # 2:end to account for event variable
+
+    # Brannmark model
+    path_yaml = joinpath(@__DIR__, "Test_ll", "Brannmark_JBC2010", "Brannmark_JBC2010.yaml")
+    petab_model = PEtabModel(path_yaml, verbose=false)
+    petab_problem = PEtabODEProblem(petab_model, verbose=false)
+    θ = petab_problem.θ_nominalT .* 0.9
+    cost = petab_problem.compute_cost(θ)
+    res = PEtabOptimisationResult(:Fides,
+                                  Vector{Vector{Float64}}(undef, 0),
+                                  Vector{Float64}(undef, 0),
+                                  10,
+                                  cost,
+                                  θ ./ 0.9,
+                                  θ,
+                                  true,
+                                  10.0)
+    c_id = :Dose_01
+    pre_eq_id = :Dose_0
+    @unpack u0, p = petab_problem.simulation_info.ode_sols[:Dose_0Dose_01].prob
+    u0_test, p_test = get_best_model_parameters(res, petab_problem, c_id; retmap=false, pre_eq_id=pre_eq_id)
+    @test all(u0_test .== u0)
+    @test all(p == p_test)
+end

--- a/test/Test_util.jl
+++ b/test/Test_util.jl
@@ -25,8 +25,8 @@ using Test
                                   10.0)
     c_id = :model1_data1
     @unpack u0, p = petab_problem.simulation_info.ode_sols[c_id].prob
-    u0_test = get_fitted_u0(res, petab_problem, c_id; retmap=false)
-    p_test = get_fitted_ps(res, petab_problem, c_id; retmap=false)
+    u0_test = get_fitted_u0(res, petab_problem; retmap=false)
+    p_test = get_fitted_ps(res, petab_problem; retmap=false)
     @test all(u0_test .== u0)
     @test all(p == p_test)
 
@@ -47,8 +47,8 @@ using Test
                                   10.0)
     c_id = :typeIDT1_ExpID1
     @unpack u0, p = petab_problem.simulation_info.ode_sols[c_id].prob
-    u0_test = get_fitted_u0(res, petab_problem, c_id; retmap=false)
-    p_test = get_fitted_ps(res, petab_problem, c_id; retmap=false)
+    u0_test = get_fitted_u0(res, petab_problem; condition_id=c_id, retmap=false)
+    p_test = get_fitted_ps(res, petab_problem; condition_id=c_id, retmap=false)
     @test all(u0_test .== u0)
     @test all(p[2:end] == p_test[2:end]) # 2:end to account for event variable
 
@@ -70,8 +70,8 @@ using Test
     c_id = :Dose_01
     pre_eq_id = :Dose_0
     @unpack u0, p = petab_problem.simulation_info.ode_sols[:Dose_0Dose_01].prob
-    p_test = get_fitted_ps(res, petab_problem, c_id; retmap=false)
-    u0_test = get_fitted_u0(res, petab_problem, c_id; retmap=false, pre_eq_id=pre_eq_id)
+    p_test = get_fitted_ps(res, petab_problem; condition_id=c_id, retmap=false)
+    u0_test = get_fitted_u0(res, petab_problem; condition_id=c_id, retmap=false, pre_eq_id=pre_eq_id)
     @test all(u0_test .== u0)
     @test all(p == p_test)
 end

--- a/test/Test_util.jl
+++ b/test/Test_util.jl
@@ -25,7 +25,8 @@ using Test
                                   10.0)
     c_id = :model1_data1
     @unpack u0, p = petab_problem.simulation_info.ode_sols[c_id].prob
-    u0_test, p_test = get_best_model_parameters(res, petab_problem, c_id; retmap=false)
+    u0_test = get_fitted_u0(res, petab_problem, c_id; retmap=false)
+    p_test = get_fitted_ps(res, petab_problem, c_id; retmap=false)
     @test all(u0_test .== u0)
     @test all(p == p_test)
 
@@ -46,7 +47,8 @@ using Test
                                   10.0)
     c_id = :typeIDT1_ExpID1
     @unpack u0, p = petab_problem.simulation_info.ode_sols[c_id].prob
-    u0_test, p_test = get_best_model_parameters(res, petab_problem, c_id; retmap=false)
+    u0_test = get_fitted_u0(res, petab_problem, c_id; retmap=false)
+    p_test = get_fitted_ps(res, petab_problem, c_id; retmap=false)
     @test all(u0_test .== u0)
     @test all(p[2:end] == p_test[2:end]) # 2:end to account for event variable
 
@@ -68,7 +70,8 @@ using Test
     c_id = :Dose_01
     pre_eq_id = :Dose_0
     @unpack u0, p = petab_problem.simulation_info.ode_sols[:Dose_0Dose_01].prob
-    u0_test, p_test = get_best_model_parameters(res, petab_problem, c_id; retmap=false, pre_eq_id=pre_eq_id)
+    p_test = get_fitted_ps(res, petab_problem, c_id; retmap=false)
+    u0_test = get_fitted_u0(res, petab_problem, c_id; retmap=false, pre_eq_id=pre_eq_id)
     @test all(u0_test .== u0)
     @test all(p == p_test)
 end

--- a/test/Test_util.jl
+++ b/test/Test_util.jl
@@ -33,7 +33,9 @@ using Test
     # Beer model
     path_yaml = joinpath(@__DIR__, "Test_ll", "Beer_MolBioSystems2014", "Beer_MolBioSystems2014.yaml")
     petab_model = PEtabModel(path_yaml, verbose=false, build_julia_files=true)
-    petab_problem = PEtabODEProblem(petab_model, verbose=false)
+    petab_problem = PEtabODEProblem(petab_model, verbose=false, 
+                                    ode_solver=ODESolver(Rodas5P()),
+                                    sparse_jacobian=false)
     θ = petab_problem.θ_nominalT .* 0.9
     cost = petab_problem.compute_cost(θ)
     res = PEtabOptimisationResult(:Fides,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,10 @@ end
   include("Test_ll.jl")
 end
 
+@safetestset "Utility functions" begin
+  include(joinpath(@__DIR__, "Test_util.jl"))
+end
+
 
 @safetestset "PEtab test suite" begin
   include("PEtab_test_suite.jl")


### PR DESCRIPTION
See #85 

The new function can cover pre-eq (by unfortunately having to rerun the pre-eq simulation but there is no way around), and model with condition specific parameters. Moreover, either a map or vector can be returned via `retmap`. 

The function is tested.

I am struggling a bit with finding a good name. Feedback appreciated @TorkelE. 

When all looks good I can improve docstring and merge with main.