### PR TITLE
Improve plot display

### DIFF
--- a/docs/src/optimisation_output_plotting.md
+++ b/docs/src/optimisation_output_plotting.md
@@ -12,6 +12,7 @@ First, we load a multi start optimisation result:
 using PEtab
 using Plots
 petab_ms_res = PEtabMultistartOptimisationResult(joinpath(@__DIR__, "assets", "optimisation_results", "boehm"))
+default(left_margin=7Plots.Measures.mm, bottom_margin=7Plots.Measures.mm) # hide
 nothing # hide
 ```
 next, we will, throughout the following sections, demonstrate the available types of plots using `petab_ms_res` as input.


### PR DESCRIPTION
Currently, in: https://sebapersson.github.io/PEtab.jl/stable/optimisation_output_plotting/ some of the ticks and guides are cut out. This attempts to fix that.

Example:
![image](https://github.com/sebapersson/PEtab.jl/assets/18099310/7edb382d-31ea-457d-8e86-418dea3a61f6)
