### PR TITLE
Allow initialisation prior when defining model in Julia.

### DIFF
--- a/docs/src/Define_in_julia.md
+++ b/docs/src/Define_in_julia.md
@@ -97,10 +97,11 @@ If you have prior information about parameters, you can specify a continuous pri
 
 ```@example 1; ansicolor=false
 using Distributions
-_se0 = PEtabParameter(:se0, prior=LogNormal(log(3.1), 0.5), prior_on_linear_scale=true)
+_se0 = PEtabParameter(:se0, prior=LogNormal(log(3.1), 0.5), 
+                      prior_on_linear_scale=true, sample_from_prior=true)
 ```
 
-In this case, `prior_on_linear_scale=true` (default) indicates that the prior is defined on the linear scale, not the default transformed log10 scale used for parameter estimation.
+In this case, `prior_on_linear_scale=true` (default) indicates that the prior is defined on the linear scale, not the default transformed log10 scale used for parameter estimation. Furthermore, when generating start-guesses for parameter estimation, you have the option to generate them from the prior distribution (instead of randomly within the upper and lower bounds) by setting `sample_from_prior=true` (default is false).
 
 Apart from estimating parameters in the reaction system, you can also estimate parameters related to measurement noise or parameters used exclusively in the observable formula (e.g., `scale` and `offset` parameters see above) by defining them as a `PEtabParameter`:
 
@@ -257,7 +258,8 @@ observables = Dict("obs_P" => obs_P,
 
 # Define parameters for estimation
 _c3 = PEtabParameter(:c3, scale=:log10)
-_se0 = PEtabParameter(:c3, prior=LogNormal(1.0, 0.5), prior_on_linear_scale=true)
+_se0 = PEtabParameter(:se0, prior=LogNormal(log(3.1), 0.5), 
+                      prior_on_linear_scale=true, sample_from_prior=true)
 _c2 = PEtabParameter(:c2)
 _sigma = PEtabParameter(:sigma)
 _scale = PEtabParameter(:scale)

--- a/docs/src/Define_in_julia.md
+++ b/docs/src/Define_in_julia.md
@@ -101,7 +101,7 @@ _se0 = PEtabParameter(:se0, prior=LogNormal(log(3.1), 0.5),
                       prior_on_linear_scale=true, sample_from_prior=true)
 ```
 
-In this case, `prior_on_linear_scale=true` (default) indicates that the prior is defined on the linear scale, not the default transformed log10 scale used for parameter estimation. Furthermore, when generating start-guesses for parameter estimation, you have the option to generate them from the prior distribution (instead of randomly within the upper and lower bounds) by setting `sample_from_prior=true` (default is false).
+In this case, `prior_on_linear_scale=true` (default) indicates that the prior is defined on the linear scale, not the default transformed log10 scale used for parameter estimation. Moreover, for parameters with priors, start-guesses for parameter estimation are generated from the prior distribution (instead of randomly within the upper and lower bounds), if you want to disable this for a specific parameter set `sample_from_prior=false` (default is true), more information can be found [here](@ref get_startguesses).
 
 Apart from estimating parameters in the reaction system, you can also estimate parameters related to measurement noise or parameters used exclusively in the observable formula (e.g., `scale` and `offset` parameters see above) by defining them as a `PEtabParameter`:
 

--- a/docs/src/Parameter_estimation.md
+++ b/docs/src/Parameter_estimation.md
@@ -146,3 +146,5 @@ using QuasiMonteCarlo
 p0 = generate_startguesses(petab_problem, 10, 
                            sampling_method=SobolSample())
 ```
+
+Additionally, if an initialization prior is specified for a parameter, the start-guesses for that parameter will be sampled from the provided prior clipped by the upper and lower bounds.

--- a/docs/src/Parameter_estimation.md
+++ b/docs/src/Parameter_estimation.md
@@ -95,8 +95,8 @@ using Ipopt
 petab_model = PEtabModel(path_yaml)
 petab_problem = PEtabODEProblem(petab_model)
 res = calibrate_model_multistart(petab_problem, IpoptOptimiser(false), 10, dir_save,
-                               save_trace=true,
-                               seed=123)
+                                 save_trace=true,
+                                 seed=123)
 print(res)
 ```
 ```
@@ -114,6 +114,22 @@ In this example, we use `save_trace=true` to enable trace saving and set `seed=1
 res.runs[1].xtrace
 res.runs[1].ftrace
 ```
+
+## [Generating startguesses for parameter estimation](@id get_startguesses)
+
+When you call the `calibrate_model_multistart` function, it uses the `generate_startguesses` function to create initial startguesses for parameter estimation. With `generate_startguesses`, you can generate start-guesses within the bounds of the `PEtabODEProblem` using various sampling methods from [QuasiMonteCarlo](https://github.com/SciML/QuasiMonteCarlo.jl) through the `sampling_method` parameter. For example, to run 10 optimization runs with Sobol sampling, do:
+
+```julia
+using QuasiMonteCarlo
+res = calibrate_model_multistart(petab_problem, IpoptOptimiser(false), 10, dir_save,
+                                 sampling_method=SobolSample(),
+                                 save_trace=true,
+                                 seed=123)
+```
+
+In addition for problems specified directly in Julia, when a parameter has a prior, the start-guesses for said parameter are sampled from the prior distribution, where the prior is clipped/truncated by the parameter's lower and upper bounds. You can disable this for all parameters by setting `sample_from_prior=false`. To disable it for specific parameters, use `sample_from_prior=false` when creating the `PEtabParameter`. For example: `PEtabParameters(:c1, sample_from_prior=false)`.
+
+For problems specified in the PEtab table format, the `initializationPriorType` must be provided to sample initial values from priors. See the [PEtab documentation](https://petab.readthedocs.io/en/latest/documentation_data_format.html#parameter-table) for details.
 
 ## Single-Start Parameter Estimation
 
@@ -138,13 +154,3 @@ Optimiser algorithm   = Ipopt_user_Hessian
 ```
 
 The results are returned as a `PEtabOptimisationResult`, which includes the following information: minimum parameter values found (`xmin`), smallest objective value (`fmin`), number of iterations, runtime, whether the optimizer converged, and optionally, the trace if `save_trace=true`.
-
-Note that `generate_startguesses` can generate several start-guesses within the bounds of the `PEtabODEProblem` with any sampling method from [QuasiMonteCarlo](https://github.com/SciML/QuasiMonteCarlo.jl). For example, to generate 10 start guesses with Sobol sampling do:
-
-```julia
-using QuasiMonteCarlo
-p0 = generate_startguesses(petab_problem, 10, 
-                           sampling_method=SobolSample())
-```
-
-Additionally, if an initialization prior is specified for a parameter, the start-guesses for that parameter will be sampled from the provided prior clipped by the upper and lower bounds.

--- a/ext/PEtabFidesExtension/Setup_fides.jl
+++ b/ext/PEtabFidesExtension/Setup_fides.jl
@@ -8,13 +8,14 @@ function PEtab.calibrate_model_multistart(petab_problem::PEtab.PEtabODEProblem,
                                           n_multistarts::Signed, 
                                           dir_save::Union{Nothing, String};
                                           sampling_method::T=QuasiMonteCarlo.LatinHypercubeSample(),
+                                          sample_from_prior::Bool=true,
                                           options=py"{'maxiter' : 1000}"o,
                                           seed::Union{Nothing, Integer}=nothing, 
                                           save_trace::Bool=false)::PEtab.PEtabMultistartOptimisationResult where T <: QuasiMonteCarlo.SamplingAlgorithm
     if !isnothing(seed)
         Random.seed!(seed)
     end
-    res = PEtab._calibrate_model_multistart(petab_problem, alg, n_multistarts, dir_save, sampling_method, options, save_trace)
+    res = PEtab._calibrate_model_multistart(petab_problem, alg, n_multistarts, dir_save, sampling_method, options, sample_from_prior, save_trace)
     return res
 end
 

--- a/ext/PEtabIpoptExtension/Setup_ipopt.jl
+++ b/ext/PEtabIpoptExtension/Setup_ipopt.jl
@@ -8,13 +8,14 @@ function PEtab.calibrate_model_multistart(petab_problem::PEtabODEProblem,
                                           n_multistarts::Signed, 
                                           dir_save::Union{Nothing, String};
                                           sampling_method::T=QuasiMonteCarlo.LatinHypercubeSample(),
+                                          sample_from_prior::Bool=true,
                                           options::IpoptOptions=IpoptOptions(),
                                           seed::Union{Nothing, Integer}=nothing, 
                                           save_trace::Bool=false)::PEtab.PEtabMultistartOptimisationResult where T <: QuasiMonteCarlo.SamplingAlgorithm
     if !isnothing(seed)
         Random.seed!(seed)
     end
-    res = PEtab._calibrate_model_multistart(petab_problem, alg, n_multistarts, dir_save, sampling_method, options, save_trace)
+    res = PEtab._calibrate_model_multistart(petab_problem, alg, n_multistarts, dir_save, sampling_method, options, sample_from_prior, save_trace)
     return res
 end
 

--- a/ext/PEtabOptimExtension/Setup_optim.jl
+++ b/ext/PEtabOptimExtension/Setup_optim.jl
@@ -7,6 +7,7 @@ function PEtab.calibrate_model_multistart(petab_problem::PEtabODEProblem,
                                           n_multistarts::Signed, 
                                           dir_save::Union{Nothing, String};
                                           sampling_method::T=QuasiMonteCarlo.LatinHypercubeSample(),
+                                          sample_from_prior::Bool=true,
                                           options::Optim.Options=Optim.Options(iterations = 1000,
                                                                                show_trace = false,
                                                                                allow_f_increases=true,
@@ -19,7 +20,7 @@ function PEtab.calibrate_model_multistart(petab_problem::PEtabODEProblem,
     if !isnothing(seed)
         Random.seed!(seed)
     end
-    res = PEtab._calibrate_model_multistart(petab_problem, alg, n_multistarts, dir_save, sampling_method, options, save_trace)
+    res = PEtab._calibrate_model_multistart(petab_problem, alg, n_multistarts, dir_save, sampling_method, options, sample_from_prior, save_trace)
     return res
 end
 

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -231,9 +231,9 @@ function transformθ(θ::AbstractVector{T},
 end
 
 
-function transform_θ_element(θ_element,
-                           scale::Symbol;
-                           reverse_transform::Bool=false)::Real
+function transform_θ_element(θ_element::T,
+                             scale::Symbol;
+                             reverse_transform::Bool=false)::T where T<:Real
 
     if scale === :lin
         return θ_element

--- a/src/Compute_cost/Compute_priors.jl
+++ b/src/Compute_cost/Compute_priors.jl
@@ -2,7 +2,7 @@
 # scale (θT)
 function compute_priors(θ_parameter_scale::AbstractVector,
                         θ_linear_scale::AbstractVector,
-                        n_parameters_estimate::Vector{Symbol},
+                        θ_names::Vector{Symbol},
                         prior_info::PriorInfo)::Real
 
     if prior_info.has_priors == false
@@ -10,12 +10,14 @@ function compute_priors(θ_parameter_scale::AbstractVector,
     end
 
     prior_value = 0.0
-    for (i, θ_name) in pairs(n_parameters_estimate)
-        logpdf = prior_info.logpdf[θ_name]
+    for (θ_name, logpdf) in prior_info.logpdf
+    
+        iθ = findfirst(x -> x == θ_name, θ_names)
+
         if prior_info.prior_on_parameter_scale[θ_name] == true
-            prior_value += logpdf(θ_parameter_scale[i])
+            prior_value += logpdf(θ_parameter_scale[iθ])
         else
-            prior_value += logpdf(θ_linear_scale[i])
+            prior_value += logpdf(θ_linear_scale[iθ])
         end
     end
 

--- a/src/Create_PEtabODEProblem/Create_PEtab_ODEProblem.jl
+++ b/src/Create_PEtabODEProblem/Create_PEtab_ODEProblem.jl
@@ -243,7 +243,8 @@ function PEtabODEProblem(petab_model::PEtabModel;
                                     θ_indices,
                                     simulation_info,
                                     _ode_problem,
-                                    split_over_conditions)
+                                    split_over_conditions, 
+                                    prior_info)
     return petab_problem
 end
 

--- a/src/Create_PEtabODEProblem/Remake_PEtabODEProblem.jl
+++ b/src/Create_PEtabODEProblem/Remake_PEtabODEProblem.jl
@@ -186,6 +186,7 @@ function remake_PEtab_problem(petab_problem::PEtabODEProblem, parameters_change:
                                     petab_problem.θ_indices,
                                     petab_problem.simulation_info,
                                     petab_problem.ode_problem,
-                                    petab_problem.split_over_conditions)
+                                    petab_problem.split_over_conditions, 
+                                    petab_problem.prior_info)
     return _petab_problem
 end

--- a/src/Model_callibration/Common.jl
+++ b/src/Model_callibration/Common.jl
@@ -294,7 +294,7 @@ end
 
 Draw `n_samples` from distribituion `dist` truncated at `lower_bound` and `upper_bound`.
 
-Used for generating start-guesses for calibration when the user has provided an initialisation prior.
+Used for generating start-guesses for calibration when the user has provided an git p.
 """
 function sample_from_prior(n_samples::Int64,
                            dist::Distribution{Univariate, Continuous},

--- a/src/PEtab_structs.jl
+++ b/src/PEtab_structs.jl
@@ -242,6 +242,16 @@ struct ParameterIndices
 end
 
 
+struct PriorInfo
+    logpdf::Dict{Symbol, Function}
+    distribution::Dict{Symbol, Distribution{Univariate, Continuous}}
+    initialisation_distribution::Dict{Symbol, Distribution{Univariate, Continuous}}
+    prior_on_parameter_scale::Dict{<:Symbol, <:Bool}
+    has_priors::Bool
+end
+
+
+
 """
     PEtabODEProblem
 
@@ -305,6 +315,7 @@ struct PEtabODEProblem{F1<:Function,
     simulation_info::SimulationInfo
     ode_problem::ODEProblem
     split_over_conditions::Bool
+    prior_info::PriorInfo
 end
 
 
@@ -377,13 +388,6 @@ end
 struct PEtabODESolverCache
     p_ode_problem_cache
     u0_cache
-end
-
-
-struct PriorInfo
-    logpdf::Dict{Symbol, Function}
-    prior_on_parameter_scale::Dict{<:Symbol, <:Bool}
-    has_priors::Bool
 end
 
 
@@ -702,7 +706,7 @@ end
 
 
 """
-    PEtabParameter(id::Symbol; <keyword arguments>)
+    PEtabParameter(id::Union{Num, Symbol}; <keyword arguments>)
 
 Represents a parameter to be estimated in a PEtab model calibration problem.
 
@@ -714,6 +718,7 @@ Represents a parameter to be estimated in a PEtab model calibration problem.
 - `ub::Float64=1e-3`: The upper parameter bound in parameter estimation (default: 1e3).
 - `prior=nothing`: An optional continuous prior distribution from the Distributions package.
 - `prior_on_linear_scale::Bool=true`: Specifies whether the prior is on the linear scale (default) or the transformed scale, e.g., log10-scale.
+- `sample_from_prior::Bool=false`: Whether to sample start-guesses from the prior distribution prior when generating startguesses for model calibration.
 
 ## Examples
 ```julia 
@@ -734,6 +739,7 @@ struct PEtabParameter
     prior::Union{Nothing,Distribution{Univariate, Continuous}}
     prior_on_linear_scale::Bool
     scale::Union{Nothing,Symbol} # :log10, :linear and :log supported.
+    sample_from_prior::Bool
 end
 function PEtabParameter(id::Union{Num, Symbol};
                         estimate::Bool=true,
@@ -742,9 +748,10 @@ function PEtabParameter(id::Union{Num, Symbol};
                         ub::Union{Nothing, Float64}=1e3,
                         prior::Union{Nothing,Distribution{Univariate, Continuous}}=nothing,
                         prior_on_linear_scale::Bool=true,
-                        scale::Union{Nothing, Symbol}=:log10)
+                        scale::Union{Nothing, Symbol}=:log10, 
+                        sample_from_prior::Bool=false)
 
-    return PEtabParameter(id, estimate, value, lb, ub, prior, prior_on_linear_scale, scale)
+    return PEtabParameter(id, estimate, value, lb, ub, prior, prior_on_linear_scale, scale, sample_from_prior)
 end
 
 

--- a/src/PEtab_structs.jl
+++ b/src/PEtab_structs.jl
@@ -718,7 +718,7 @@ Represents a parameter to be estimated in a PEtab model calibration problem.
 - `ub::Float64=1e-3`: The upper parameter bound in parameter estimation (default: 1e3).
 - `prior=nothing`: An optional continuous prior distribution from the Distributions package.
 - `prior_on_linear_scale::Bool=true`: Specifies whether the prior is on the linear scale (default) or the transformed scale, e.g., log10-scale.
-- `sample_from_prior::Bool=false`: Whether to sample start-guesses from the prior distribution prior when generating startguesses for model calibration.
+- `sample_from_prior::Bool=true`: Whether to sample the parameter from the prior distribution when generating startguesses for model calibration.
 
 ## Examples
 ```julia 
@@ -749,7 +749,7 @@ function PEtabParameter(id::Union{Num, Symbol};
                         prior::Union{Nothing,Distribution{Univariate, Continuous}}=nothing,
                         prior_on_linear_scale::Bool=true,
                         scale::Union{Nothing, Symbol}=:log10, 
-                        sample_from_prior::Bool=false)
+                        sample_from_prior::Bool=true)
 
     return PEtabParameter(id, estimate, value, lb, ub, prior, prior_on_linear_scale, scale, sample_from_prior)
 end

--- a/src/Process_PEtab_files/Julia_tables_provided/Parse_input.jl
+++ b/src/Process_PEtab_files/Julia_tables_provided/Parse_input.jl
@@ -106,19 +106,27 @@ function parse_petab_parameters(petab_parameters::Vector{PEtabParameter},
     end
 
     priors = Vector{String}(undef, length(petab_parameters))
+    initialisation_priors = similar(priors)
     prior_on_linear_scale = Vector{Union{Bool, String}}(undef, length(petab_parameters))
     for i in eachindex(priors)
         if isnothing(petab_parameters[i].prior)
             priors[i] = ""
             prior_on_linear_scale[i] = ""
+            initialisation_priors[i] = ""
             continue
         end
 
         priors[i] = "__Julia__" * string(petab_parameters[i].prior)
         prior_on_linear_scale[i] = petab_parameters[i].prior_on_linear_scale
+        if petab_parameters[i].sample_from_prior == true
+            initialisation_priors[i] = priors[i]
+        else
+            initialisation_priors[i] = ""
+        end
     end
     df[!, :objectivePriorType] = priors
     df[!, :priorOnLinearScale] = prior_on_linear_scale
+    df[!, :initializationPriorType] = initialisation_priors
     return df
 end
 

--- a/src/SBML/SBML_rules.jl
+++ b/src/SBML/SBML_rules.jl
@@ -1,9 +1,8 @@
-function parse_SBML_rules!(model_dict::Dict, model_SBML::SBML.Model)
+function parse_SBML_rules!(model_dict::Dict, model_SBML::SBML.Model)::Nothing
 
     for rule in model_SBML.rules
 
         if rule isa SBML.AssignmentRule
-            push!(model_dict["assignment_rule_variables"], rule.variable)
             parse_assignment_rule!(model_dict, rule, model_SBML)
         end
 
@@ -16,6 +15,7 @@ function parse_SBML_rules!(model_dict::Dict, model_SBML::SBML.Model)
             parse_algebraic_rule!(model_dict, rule)
         end
     end    
+    return nothing
 end
 
 

--- a/src/SBML/SBML_to_ModellingToolkit.jl
+++ b/src/SBML/SBML_to_ModellingToolkit.jl
@@ -35,22 +35,21 @@ end
 
 function build_model_dict(model_SBML, ifelse_to_event::Bool)
 
-    # Nested dictionaries to act as intermedidate struct to store relevent 
+    # Nested dictionaries to act as intermedidate struct to store relevent
     # model data
-    model_dict = Dict("species" => Dict{String, SpecieSBML}(), 
-                      "parameters" => Dict{String, ParameterSBML}(), 
-                      "compartments" => Dict{String, CompartmentSBML}(), 
-                      "SBML_functions" => Dict{String, Vector{String}}(), 
-                      "ifelse_parameters" => Dict(), 
-                      "events" => Dict{String, EventSBML}(), 
-                      "reactions" => Dict{String, ReactionSBML}(), 
-                      "algebraic_rules" => Dict{String, String}(), 
-                      "generated_ids" => Dict{String, String}(), 
+    model_dict = Dict("species" => Dict{String, SpecieSBML}(),
+                      "parameters" => Dict{String, ParameterSBML}(),
+                      "compartments" => Dict{String, CompartmentSBML}(),
+                      "SBML_functions" => Dict{String, Vector{String}}(),
+                      "ifelse_parameters" => Dict(),
+                      "events" => Dict{String, EventSBML}(),
+                      "reactions" => Dict{String, ReactionSBML}(),
+                      "algebraic_rules" => Dict{String, String}(),
+                      "generated_ids" => Dict{String, String}(),
                       "piecewise_expressions" => Dict{String, String}(),
                       "ifelse_bool_expressions" => Dict{String, String}(),
-                      "assignment_rule_variables" => String[], 
-                      "rate_rule_variables" => String[], 
-                      "appear_in_reactions" => String[], 
+                      "rate_rule_variables" => String[],
+                      "appear_in_reactions" => String[],
                       "has_piecewise" => String[])
 
     parse_SBML_species!(model_dict, model_SBML)
@@ -87,7 +86,7 @@ function build_model_dict(model_SBML, ifelse_to_event::Bool)
 
     adjust_conversion_factor!(model_dict, model_SBML)
 
-    # Ensure that event participating parameters and compartments are not simplfied away when calling 
+    # Ensure that event participating parameters and compartments are not simplfied away when calling
     # structurally_simplify
     include_event_parameters_in_model!(model_dict)
 
@@ -241,10 +240,10 @@ function create_ode_model(model_dict, path_jl_file, model_name, write_to_file::B
     end
     # Compartments
     for (compartment_id, compartment) in model_dict["compartments"]
-        if compartment.rate_rule != true 
+        if compartment.rate_rule != true
             continue
         end
-        u0eq = compartment.initial_value        
+        u0eq = compartment.initial_value
         dict_model_str["specie_map"] *= "\t" * compartment_id * " => " * u0eq * ",\n"
     end
     dict_model_str["specie_map"] *= "\t]"

--- a/src/SBML/Structs.jl
+++ b/src/SBML/Structs.jl
@@ -51,3 +51,21 @@ mutable struct ReactionSBML
     const reactants::Vector{String}
     const reactants_stoichiometry::Vector{String}
 end
+
+
+struct ModelSBML
+    species::Dict{String, SpecieSBML}
+    parameters::Dict{String, ParameterSBML}
+    compartments::Dict{String, CompartmentSBML}
+    events::Dict{String, EventSBML}
+    reactions::Dict{String, ReactionSBML}
+    algebraic_rules::Dict{String, String}
+    generated_ids::Dict{String, String}
+    piecewise_expressions::Dict{String, String}
+    ifelse_bool_expressions::Dict{String, String}
+    assignment_rule_variables::Vector{String}
+    ifelse_parameters::Vector{String}
+    rate_rule_variables::Vector{String}
+    appear_in_reactions::Vector{String}
+    has_piecewise::Vector{String}
+end

--- a/src/Utility.jl
+++ b/src/Utility.jl
@@ -17,7 +17,7 @@ If a parameter vector is provided it must have the parameters in the same order 
 Potential events are accounted for when solving the ODE model. The ODE solver options specified when creating the 
 `petab_problem` are used for solving the model.
 """
-function get_odesol(θ::Vector{Float64},
+function get_odesol(res::Union{PEtabOptimisationResult, PEtabMultistartOptimisationResult, Vector{Float64}},
                     petab_problem::PEtabODEProblem;
                     condition_id::Union{String, Symbol, Nothing}=nothing,
                     pre_eq_id::Union{String, Symbol, Nothing}=nothing)
@@ -33,7 +33,7 @@ function get_odesol(θ::Vector{Float64},
         pre_eq_id = Symbol(pre_eq_id)
     end
 
-    u0, p = _get_fitted_parameters(θ, petab_problem, condition_id, pre_eq_id, false)
+    u0, p = _get_fitted_parameters(res, petab_problem, condition_id, pre_eq_id, false)
     tmax = petab_problem.simulation_info.tmax[condition_id]
     ode_problem = remake(petab_problem.ode_problem, p=p, u0=u0, tspan=(0.0, tmax))
 
@@ -72,7 +72,7 @@ prob, cb, tstops = get_odeproblem(res, petab_problem, condition_id="cond1")
 sol = solve(prob, Rodas5P(), callback=cb, tstops=tstops)
 ```
 """
-function get_odeproblem(θ::Vector{Float64},
+function get_odeproblem(res::Union{PEtabOptimisationResult, PEtabMultistartOptimisationResult, Vector{Float64}},
                         petab_problem::PEtabODEProblem;
                         condition_id::Union{String, Symbol, Nothing}=nothing,
                         pre_eq_id::Union{String, Symbol, Nothing}=nothing)
@@ -82,7 +82,7 @@ function get_odeproblem(θ::Vector{Float64},
         condition_id = simulation_info.simulation_condition_id[1]
     end
 
-    u0, p = _get_fitted_parameters(θ, petab_problem, condition_id, pre_eq_id, false)
+    u0, p = _get_fitted_parameters(res, petab_problem, condition_id, pre_eq_id, false)
     tmax = petab_problem.simulation_info.tmax[condition_id]
     ode_problem = remake(petab_problem.ode_problem, p=p, u0=u0, tspan=(0.0, tmax))
 
@@ -109,9 +109,9 @@ If a parameter vector is provided it must have the parameters in the same order 
 If `retmap=true`, a parameter vector is returned; otherwise, a vector is returned.
 """
 function get_ps(res::Union{PEtabOptimisationResult, PEtabMultistartOptimisationResult, Vector{Float64}}, 
-                       petab_problem::PEtabODEProblem;
-                       condition_id::Union{String, Symbol, Nothing}=nothing,
-                       retmap=true)
+                petab_problem::PEtabODEProblem;
+                condition_id::Union{String, Symbol, Nothing}=nothing,
+                retmap=true)
 
     u0, p = _get_fitted_parameters(res, petab_problem, condition_id, nothing, retmap)
     return p
@@ -139,10 +139,11 @@ If a parameter vector is provided it must have the parameters in the same order 
 If `retmap=true`, a parameter vector is returned; otherwise, a vector is returned.
 """
 function get_u0(res::Union{PEtabOptimisationResult, PEtabMultistartOptimisationResult, Vector{Float64}}, 
-                       petab_problem::PEtabODEProblem;
-                       condition_id::Union{String, Symbol, Nothing}=nothing,
-                       pre_eq_id::Union{String, Symbol, Nothing}=nothing, 
-                       retmap::Bool=true)
+                petab_problem::PEtabODEProblem;
+                condition_id::Union{String, Symbol, Nothing}=nothing,
+                pre_eq_id::Union{String, Symbol, Nothing}=nothing, 
+                retmap::Bool=true)
+
     u0, p = _get_fitted_parameters(res, petab_problem, condition_id, pre_eq_id, retmap)
     return u0
 end

--- a/test/Test_util.jl
+++ b/test/Test_util.jl
@@ -28,8 +28,14 @@ using Test
     @unpack u0, p = petab_problem.simulation_info.ode_sols[c_id].prob
     u0_test = get_u0(res, petab_problem; retmap=false)
     p_test = get_ps(res, petab_problem; retmap=false)
+    odeprob, _, _ = get_odeproblem(res, petab_problem)    
+    sol = get_odesol(res, petab_problem)
     @test all(u0_test .== u0)
-    @test all(p == p_test)
+    @test all(p_test == p)
+    @test all(odeprob.u0 .== u0)
+    @test all(odeprob.p == p)
+    @test all(sol.prob.u0 .== u0)
+    @test all(sol.prob.p == p)
 
     # Beer model
     path_yaml = joinpath(@__DIR__, "Test_ll", "Beer_MolBioSystems2014", "Beer_MolBioSystems2014.yaml")
@@ -76,8 +82,8 @@ using Test
     c_id = :Dose_01
     pre_eq_id = :Dose_0
     @unpack u0, p = petab_problem.simulation_info.ode_sols[:Dose_0Dose_01].prob
-    p_test = get_ps(res, petab_problem; condition_id=c_id, retmap=false)
-    u0_test = get_u0(res, petab_problem; condition_id=c_id, retmap=false, pre_eq_id=pre_eq_id)
+    p_test = get_ps(res.xmin, petab_problem; condition_id=c_id, retmap=false)
+    u0_test = get_u0(res.xmin, petab_problem; condition_id=c_id, retmap=false, pre_eq_id=pre_eq_id)
     @test all(u0_test .== u0)
     @test all(p == p_test)
 end


### PR DESCRIPTION
When generating startguesses for parameter estimation it can be relevant to sample these from the prior, instead of from the uniform intervall upper and lower bounds. When defining a model in Julia this is now allowed when setting sample_from_prior=true for a PEtabParameter