### PR TITLE
Add PyCall to test-suite and GitHub CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - run: >
+          sudo apt-get install --no-install-recommends gfortran python3-setuptools python3-wheel
+          && pip3 install fides petab-select
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,23 +19,31 @@ jobs:
       matrix:
         version:
           - '1.10'
+        python: [3.10]
         os:
           - ubuntu-latest
         arch:
           - x64
-    env:
-      PYTHON: python3
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }} 
+     - name: Set ENV Variables for Python
+        run: echo ENV["PYTHON"] = "${{ env.pythonLocation }}/bin/python" >> $GITHUB_ENV
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install fides petab-select
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - run: >
-          sudo apt-get install --no-install-recommends gfortran python3-setuptools python3-wheel
-          && pip3 install numpy scipy && pip3 install fides petab-select
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
+        env:
+          PYTHON : "${{ env.pythonLocation }}/bin/python"
       - uses: julia-actions/julia-runtest@v1
         continue-on-error: ${{ matrix.version == 'nightly' }}
   docs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         version:
           - '1.10'
-        python: [3.10]
+        python: [3.10.13]
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,28 +12,42 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1.10'
-          - 'nightly'
+        julia-version: [1.10]
+        python-version: [3.10]
         os:
           - ubuntu-latest
         arch:
           - x64
-    env:
-      PYTHON: ""
+  name: Test
+    Julia ${{ matrix.julia-version }}
+    Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
+
+      - name: Set ENV Variables Python
+        run: echo ENV["PYTHON"] = "${{ env.pythonLocation }}/bin/python" >> $GITHUB_ENV
+      
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install fides petab-select
+
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
+        env:
+          PYTHON : "${{ env.pythonLocation }}/bin/python"
       - uses: julia-actions/julia-runtest@v1
         continue-on-error: ${{ matrix.version == 'nightly' }}
   docs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }} 
-     - name: Set ENV Variables for Python
+      - name: Set ENV Variables for Python
         run: echo ENV["PYTHON"] = "${{ env.pythonLocation }}/bin/python" >> $GITHUB_ENV
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install fides petab-select
+          pip install fides petab-select==0.1.10
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
           arch: ${{ matrix.arch }}
       - run: >
           sudo apt-get install --no-install-recommends gfortran python3-setuptools python3-wheel
-          && pip3 install fides petab-select
+          && pip3 install numpy scipy && pip3 install fides petab-select
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,35 +12,27 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1.10]
-        python-version: [3.10]
+        version:
+          - '1.10'
         os:
           - ubuntu-latest
         arch:
           - x64
+    env:
+      PYTHON: python3
     steps:
       - uses: actions/checkout@v2
-      - name: Setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.architecture }}
-      - name: Set ENV Variables Python
-        run: echo ENV["PYTHON"] = "${{ env.pythonLocation }}/bin/python" >> $GITHUB_ENV
-      - run: python -m pip install --upgrade pip
-      - run: python -m pip install fides petab-select
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
-        env:
-          PYTHON : "${{ env.pythonLocation }}/bin/python"
       - uses: julia-actions/julia-runtest@v1
         continue-on-error: ${{ matrix.version == 'nightly' }}
   docs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,24 +22,17 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
-  name: Test
-    Julia ${{ matrix.julia-version }}
-    Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
-
       - name: Setup python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
-
       - name: Set ENV Variables Python
         run: echo ENV["PYTHON"] = "${{ env.pythonLocation }}/bin/python" >> $GITHUB_ENV
-      
       - run: python -m pip install --upgrade pip
       - run: python -m pip install fides petab-select
-
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}

--- a/Project.toml
+++ b/Project.toml
@@ -101,4 +101,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "Test", "SafeTestsets", "SciMLSensitivity", "Zygote", "Ipopt", "Optim", "Plots", "Optimization", "OptimizationOptimJL", "FiniteDifferences"]
+test = ["Aqua", "Test", "SafeTestsets", "SciMLSensitivity", "Zygote", "Ipopt", "Optim", "Plots", "Optimization", "OptimizationOptimJL", "FiniteDifferences", "PyCall"]

--- a/test/PEtab_select.jl
+++ b/test/PEtab_select.jl
@@ -44,7 +44,7 @@ using Test
 
     path_yaml = joinpath(@__DIR__, "petab_select", "0006", "petab_select_problem.yaml")
     path_exepected = joinpath(@__DIR__, "petab_select", "0006", "expected.yaml")
-    path_save = run_PEtab_select(path_yaml, Fides(:BFGS, verbose=false), n_multistarts=10)
+    path_save = run_PEtab_select(path_yaml, IPNewton(), n_multistarts=20)
     expected_res = YAML.load_file(path_exepected)
     data_res = YAML.load_file(path_save)
     @test expected_res["criteria"]["NLLH"] ≈ data_res["criteria"]["NLLH"] atol=1e-3

--- a/test/PEtab_select.jl
+++ b/test/PEtab_select.jl
@@ -1,0 +1,65 @@
+using PEtab
+using OrdinaryDiffEq
+using Optim
+using PyCall
+using YAML
+using Test
+
+@testset "PEtab-select" begin
+
+    path_yaml = joinpath(@__DIR__, "petab_select", "0001", "petab_select_problem.yaml")
+    path_exepected = joinpath(@__DIR__, "petab_select", "0001", "expected.yaml")
+    path_save = run_PEtab_select(path_yaml, IPNewton())
+    expected_res = YAML.load_file(path_exepected)
+    data_res = YAML.load_file(path_save)
+    @test expected_res["criteria"]["NLLH"] ≈ data_res["criteria"]["NLLH"] atol=1e-3
+
+    path_yaml = joinpath(@__DIR__, "petab_select", "0002", "petab_select_problem.yaml")
+    path_exepected = joinpath(@__DIR__, "petab_select", "0002", "expected.yaml")
+    path_save = run_PEtab_select(path_yaml, IPNewton(), gradient_method=:ForwardDiff, hessian_method=:ForwardDiff, n_multistarts=10)
+    expected_res = YAML.load_file(path_exepected)
+    data_res = YAML.load_file(path_save)
+    @test expected_res["criteria"]["NLLH"] ≈ data_res["criteria"]["NLLH"] atol=1e-3
+
+    path_yaml = joinpath(@__DIR__, "petab_select", "0003", "petab_select_problem.yaml")
+    path_exepected = joinpath(@__DIR__, "petab_select", "0003", "expected.yaml")
+    path_save = run_PEtab_select(path_yaml, Fides(nothing), n_multistarts=10)
+    expected_res = YAML.load_file(path_exepected)
+    data_res = YAML.load_file(path_save)
+    @test expected_res["criteria"]["NLLH"] ≈ data_res["criteria"]["NLLH"] atol=1e-3
+
+    path_yaml = joinpath(@__DIR__, "petab_select", "0004", "petab_select_problem.yaml")
+    path_exepected = joinpath(@__DIR__, "petab_select", "0004", "expected.yaml")
+    path_save = run_PEtab_select(path_yaml, Fides(nothing; verbose=false), gradient_method=:ForwardEquations, hessian_method=:GaussNewton, reuse_sensitivities=true, sensealg=:ForwardDiff, n_multistarts=10)
+    expected_res = YAML.load_file(path_exepected)
+    data_res = YAML.load_file(path_save)
+    @test expected_res["criteria"]["NLLH"] ≈ data_res["criteria"]["NLLH"] atol=1e-3
+
+    path_yaml = joinpath(@__DIR__, "petab_select", "0005", "petab_select_problem.yaml")
+    path_exepected = joinpath(@__DIR__, "petab_select", "0005", "expected.yaml")
+    path_save = run_PEtab_select(path_yaml, Fides(:BFGS), gradient_method=:ForwardDiff, n_multistarts=10)
+    expected_res = YAML.load_file(path_exepected)
+    data_res = YAML.load_file(path_save)
+    @test expected_res["criteria"]["NLLH"] ≈ data_res["criteria"]["NLLH"] atol=1e-3
+
+    path_yaml = joinpath(@__DIR__, "petab_select", "0006", "petab_select_problem.yaml")
+    path_exepected = joinpath(@__DIR__, "petab_select", "0006", "expected.yaml")
+    path_save = run_PEtab_select(path_yaml, Fides(:BFGS, verbose=false), n_multistarts=10)
+    expected_res = YAML.load_file(path_exepected)
+    data_res = YAML.load_file(path_save)
+    @test expected_res["criteria"]["NLLH"] ≈ data_res["criteria"]["NLLH"] atol=1e-3
+
+    path_yaml = joinpath(@__DIR__, "petab_select", "0007", "petab_select_problem.yaml")
+    path_exepected = joinpath(@__DIR__, "petab_select", "0007", "expected.yaml")
+    path_save = run_PEtab_select(path_yaml, Fides(nothing), gradient_method=:ForwardEquations, hessian_method=:GaussNewton, reuse_sensitivities=true, sensealg=:ForwardDiff, n_multistarts=10)
+    expected_res = YAML.load_file(path_exepected)
+    data_res = YAML.load_file(path_save)
+    @test expected_res["criteria"]["NLLH"] ≈ data_res["criteria"]["NLLH"] atol=1e-3
+
+    path_yaml = joinpath(@__DIR__, "petab_select", "0008", "petab_select_problem.yaml")
+    path_exepected = joinpath(@__DIR__, "petab_select", "0008", "expected.yaml")
+    path_save = run_PEtab_select(path_yaml, Fides(nothing), gradient_method=:ForwardEquations, hessian_method=:GaussNewton, reuse_sensitivities=true, sensealg=:ForwardDiff, n_multistarts=10)
+    expected_res = YAML.load_file(path_exepected)
+    data_res = YAML.load_file(path_save)
+    @test expected_res["criteria"]["NLLH"] ≈ data_res["criteria"]["NLLH"] atol=1e-3
+end

--- a/test/petab_select/0001/PEtab_select_brute_force_AIC.yaml
+++ b/test/petab_select/0001/PEtab_select_brute_force_AIC.yaml
@@ -1,0 +1,18 @@
+criteria:
+  AIC: -6.1754054962684
+  NLLH: -4.0877027481342
+estimated_parameters:
+  sigma_x2: 0.12242920633849648
+model_hash: b655a59ac1b81e3787aa793543038ba15a7657f1737542f1e3a78e9514ec64f27e0f448a0672251c84b414a1936dd62e138963dfcfafb2de38d350953362063d
+model_id: b655a59ac1b81e3787aa793543038ba15a7657f1737542f1e3a78e9514ec64f27e0f448a0672251c84b414a1936dd62e138963dfcfafb2de38d350953362063d
+model_subspace_id: M1_1
+model_subspace_indices:
+- 0
+- 0
+- 0
+parameters:
+  k1: 0.2
+  k2: 0.1
+  k3: 0
+petab_yaml: /home/sebpe/.julia/dev/PEtab/test/petab_select/0001/petab/petab_problem.yaml
+predecessor_model_hash: null

--- a/test/petab_select/0001/expected.yaml
+++ b/test/petab_select/0001/expected.yaml
@@ -1,0 +1,18 @@
+criteria:
+  AIC: -6.175405094206667
+  NLLH: -4.0877025471033335
+estimated_parameters:
+  sigma_x2: 0.1224643186838838
+model_hash: 4fbbda138c41c1d3c9bcd538fefd1f034ba746336eec0c18f7b6032246a29361b674027c62393209d6777d70436e793cd4ba39ebd9f217d5cc33b62797138254
+model_id: 4fbbda138c41c1d3c9bcd538fefd1f034ba746336eec0c18f7b6032246a29361b674027c62393209d6777d70436e793cd4ba39ebd9f217d5cc33b62797138254
+model_subspace_id: M1_1
+model_subspace_indices:
+- 0
+- 0
+- 0
+parameters:
+  k1: 0.2
+  k2: 0.1
+  k3: 0
+petab_yaml: petab/petab_problem.yaml
+predecessor_model_hash: null

--- a/test/petab_select/0001/model_space.tsv
+++ b/test/petab_select/0001/model_space.tsv
@@ -1,0 +1,2 @@
+model_subspace_id	petab_yaml	k1	k2	k3
+M1_1	petab/petab_problem.yaml	0.2	0.1	0

--- a/test/petab_select/0001/petab/Julia_model_files/petab.jl
+++ b/test/petab_select/0001/petab/Julia_model_files/petab.jl
@@ -1,0 +1,34 @@
+function get_reaction_system(foo)
+
+	ModelingToolkit.@variables t
+	sps = Catalyst.@species x1(t) x2(t) 
+	vs = ModelingToolkit.@variables observable_x2(t) sigma_x2(t)
+	ps = Catalyst.@parameters k3 k1 k2 default 
+
+	D = Differential(t)
+
+	_reactions = [
+		Catalyst.Reaction(default*((((k3)*(x1))*(x2))/(default)), [x1, x2], nothing, [1.0/default, 1.0/default], nothing; only_use_rate=true),
+		Catalyst.Reaction(default*((k1)/(default)), nothing, [x1], nothing, [1.0/default]; only_use_rate=true),
+		Catalyst.Reaction(default*(((k2)*(x1))/(default)), [x1], [x2], [1.0/default], [1.0/default]; only_use_rate=true),
+		D(observable_x2) ~ 0.0,
+		D(sigma_x2) ~ 0.0,
+	]
+
+
+	rn = Catalyst.ReactionSystem(_reactions, t, [sps; vs], ps; name=Symbol("caroModel"), combinatoric_ratelaws=false)
+
+	specie_map = [
+	x1 =>0.0,
+	x2 =>0.0,
+	observable_x2 => 0.0,
+	sigma_x2 => 0.04,
+	]
+	parameter_map = [
+	k3 =>0.0,
+	k1 =>0.2,
+	k2 =>0.1,
+	default =>1.0,
+	]
+	return rn, specie_map, parameter_map
+end

--- a/test/petab_select/0001/petab/Julia_model_files/petab_D_h_sd.jl
+++ b/test/petab_select/0001/petab/Julia_model_files/petab_D_h_sd.jl
@@ -1,0 +1,36 @@
+#u[1] = x1, u[2] = x2, u[3] = observable_x2, u[4] = sigma_x2
+#p_ode_problem[1] = k3, p_ode_problem[2] = k1, p_ode_problem[3] = k2, p_ode_problem[4] = default
+#
+function compute_∂h∂u!(u, t::Real, p_ode_problem::AbstractVector, θ_observable::AbstractVector,
+                  θ_non_dynamic::AbstractVector, observableId::Symbol, parameter_map::θObsOrSdParameterMap, out) 
+	if observableId == :obs_x2 
+		out[2] = 1
+		return nothing
+	end
+
+end
+
+function compute_∂h∂p!(u, t::Real, p_ode_problem::AbstractVector, θ_observable::AbstractVector,
+                  θ_non_dynamic::AbstractVector, observableId::Symbol, parameter_map::θObsOrSdParameterMap, out) 
+	if observableId == :obs_x2 
+		return nothing
+	end
+
+end
+
+function compute_∂σ∂σu!(u, t::Real, θ_sd::AbstractVector, p_ode_problem::AbstractVector,  θ_non_dynamic::AbstractVector,
+                   parameter_info::ParametersInfo, observableId::Symbol, parameter_map::θObsOrSdParameterMap, out) 
+	if observableId == :obs_x2 
+		return nothing
+	end
+
+end
+
+function compute_∂σ∂σp!(u, t::Real, θ_sd::AbstractVector, p_ode_problem::AbstractVector,  θ_non_dynamic::AbstractVector,
+                   parameter_info::ParametersInfo, observableId::Symbol, parameter_map::θObsOrSdParameterMap, out) 
+	if observableId == :obs_x2 
+		return nothing
+	end
+
+end
+

--- a/test/petab_select/0001/petab/Julia_model_files/petab_callbacks.jl
+++ b/test/petab_select/0001/petab/Julia_model_files/petab_callbacks.jl
@@ -1,0 +1,11 @@
+
+
+function(foo)
+	return false 
+end
+
+
+
+function compute_tstops(u::AbstractVector, p::AbstractVector)
+	 return Float64[]
+end

--- a/test/petab_select/0001/petab/Julia_model_files/petab_h_sd_u0.jl
+++ b/test/petab_select/0001/petab/Julia_model_files/petab_h_sd_u0.jl
@@ -1,0 +1,51 @@
+#u[1] = x1, u[2] = x2, u[3] = observable_x2, u[4] = sigma_x2
+#p_ode_problem_names[1] = k3, p_ode_problem_names[2] = k1, p_ode_problem_names[3] = k2, p_ode_problem_names[4] = default
+#
+
+function compute_h(u::AbstractVector, t::Real, p_ode_problem::AbstractVector, θ_observable::AbstractVector,
+               θ_non_dynamic::AbstractVector, parameter_info::ParametersInfo, observableId::Symbol,
+                  parameter_map::θObsOrSdParameterMap)::Real 
+	if observableId === :obs_x2 
+		return u[2] 
+	end
+
+end
+
+function compute_u0!(u0::AbstractVector, p_ode_problem::AbstractVector) 
+
+	#p_ode_problem[1] = k3, p_ode_problem[2] = k1, p_ode_problem[3] = k2, p_ode_problem[4] = default
+
+	t = 0.0 # u at time zero
+
+	x1 = 0.0 
+	x2 = 0.0 
+	observable_x2 = 0.0 
+	sigma_x2 = 0.04 
+
+	u0 .= x1, x2, observable_x2, sigma_x2
+end
+
+function compute_u0(p_ode_problem::AbstractVector)::AbstractVector 
+
+	#p_ode_problem[1] = k3, p_ode_problem[2] = k1, p_ode_problem[3] = k2, p_ode_problem[4] = default
+
+	t = 0.0 # u at time zero
+
+	x1 = 0.0 
+	x2 = 0.0 
+	observable_x2 = 0.0 
+	sigma_x2 = 0.04 
+
+	 return [x1, x2, observable_x2, sigma_x2]
+end
+
+function compute_σ(u::AbstractVector, t::Real, θ_sd::AbstractVector, p_ode_problem::AbstractVector,  θ_non_dynamic::AbstractVector,
+               parameter_info::ParametersInfo, observableId::Symbol, parameter_map::θObsOrSdParameterMap)::Real 
+	if observableId === :obs_x2 
+		noiseParameter1_obs_x2 = get_obs_sd_parameter(θ_sd, parameter_map)
+		return noiseParameter1_obs_x2 
+	end
+
+
+end
+

--- a/test/petab_select/0001/petab/conditions.tsv
+++ b/test/petab_select/0001/petab/conditions.tsv
@@ -1,0 +1,2 @@
+conditionId	conditionName
+model1_data1	condition1

--- a/test/petab_select/0001/petab/measurements.tsv
+++ b/test/petab_select/0001/petab/measurements.tsv
@@ -1,0 +1,7 @@
+observableId	simulationConditionId	measurement	time	noiseParameters
+obs_x2	model1_data1	0	0	sigma_x2
+obs_x2	model1_data1	0.19421762	1	sigma_x2
+obs_x2	model1_data1	0.0484032	5	sigma_x2
+obs_x2	model1_data1	0.61288016	10	sigma_x2
+obs_x2	model1_data1	4.07930835	30	sigma_x2
+obs_x2	model1_data1	10.12008893	60	sigma_x2

--- a/test/petab_select/0001/petab/model.xml
+++ b/test/petab_select/0001/petab/model.xml
@@ -1,0 +1,315 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by COPASI version 4.24 (Build 197) on 2019-03-27 19:00 with libSBML version 5.17.0. -->
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" version="4">
+  <model metaid="COPASI0" id="caroModel_linear_petab_1" name="caroModel">
+    <annotation>
+      <COPASI xmlns="http://www.copasi.org/static/sbml">
+        <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+          <rdf:Description rdf:about="#COPASI0">
+            <dcterms:created>
+              <rdf:Description>
+                <dcterms:W3CDTF>2019-03-27T18:47:48Z</dcterms:W3CDTF>
+              </rdf:Description>
+            </dcterms:created>
+          </rdf:Description>
+        </rdf:RDF>
+      </COPASI>
+    </annotation>
+    <listOfFunctionDefinitions>
+      <functionDefinition metaid="COPASI10" id="function_for_R3" name="function for R3">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI10">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:57:38Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> k3 </ci>
+            </bvar>
+            <bvar>
+              <ci> x1 </ci>
+            </bvar>
+            <bvar>
+              <ci> x2 </ci>
+            </bvar>
+            <bvar>
+              <ci> default </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k3 </ci>
+                <ci> x1 </ci>
+                <ci> x2 </ci>
+              </apply>
+              <ci> default </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI11" id="function_for_R1" name="function for R1">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI11">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:52:47Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> k1 </ci>
+            </bvar>
+            <bvar>
+              <ci> default </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <ci> k1 </ci>
+              <ci> default </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI12" id="function_for_R2" name="function for R2">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI12">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:55:12Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> k2 </ci>
+            </bvar>
+            <bvar>
+              <ci> x1 </ci>
+            </bvar>
+            <bvar>
+              <ci> default </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k2 </ci>
+                <ci> x1 </ci>
+              </apply>
+              <ci> default </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+    </listOfFunctionDefinitions>
+    <listOfCompartments>
+      <compartment id="default" name="default" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="x1" name="x1" compartment="default" initialConcentration="0" boundaryCondition="false" constant="false"/>
+      <species id="x2" name="x2" compartment="default" initialConcentration="0" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter metaid="COPASI1" id="k1" name="k1" value="0.2" constant="true">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI1">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:59:36Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+      </parameter>
+      <parameter metaid="COPASI2" id="k2" name="k2" value="0.1" constant="true">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI2">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:59:35Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+      </parameter>
+      <parameter metaid="COPASI3" id="k3" name="k3" value="0" constant="true">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI3">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:59:34Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+      </parameter>
+      <parameter metaid="COPASI4" id="sigma_x2" name="sigma_x2" value="0.04" constant="false">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI4">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:56:09Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+      </parameter>
+      <parameter metaid="COPASI6" id="observable_x2" name="observable_x2" value="0" constant="false">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI6">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:50:50Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+      </parameter>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction metaid="COPASI7" id="R1" name="R1" reversible="false">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI7">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:53:29Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfProducts>
+          <speciesReference species="x1" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <apply>
+                <ci> function_for_R1 </ci>
+                <ci> k1 </ci>
+                <ci> default </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI8" id="R2" name="R2" reversible="false">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI8">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:55:51Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="x1" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="x2" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <apply>
+                <ci> function_for_R2 </ci>
+                <ci> k2 </ci>
+                <ci> x1 </ci>
+                <ci> default </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI9" id="R3" name="R3" reversible="false">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI9">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:49:35Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="x1" stoichiometry="1"/>
+          <speciesReference species="x2" stoichiometry="1"/>
+        </listOfReactants>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <apply>
+                <ci> function_for_R3 </ci>
+                <ci> k3 </ci>
+                <ci> x1 </ci>
+                <ci> x2 </ci>
+                <ci> default </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/petab_select/0001/petab/observables.tsv
+++ b/test/petab_select/0001/petab/observables.tsv
@@ -1,0 +1,2 @@
+observableId	observableFormula	noiseFormula
+obs_x2	x2	noiseParameter1_obs_x2

--- a/test/petab_select/0001/petab/parameters.tsv
+++ b/test/petab_select/0001/petab/parameters.tsv
@@ -1,0 +1,5 @@
+parameterId	parameterName	parameterScale	lowerBound	upperBound	nominalValue	estimate
+k1	k_{1}	lin	0	1.00E+03	0.2	1
+k2	k_{2}	lin	0	1.00E+03	0.1	1
+k3	k_{3}	lin	0	1.00E+03	0	1
+sigma_x2	\sigma_{x2}	lin	1.00E-05	1.00E+03	0.15	1

--- a/test/petab_select/0001/petab/petab_problem.yaml
+++ b/test/petab_select/0001/petab/petab_problem.yaml
@@ -1,0 +1,11 @@
+format_version: 1
+parameter_file: parameters.tsv
+problems:
+- condition_files:
+  - conditions.tsv
+  measurement_files:
+  - measurements.tsv
+  observable_files:
+  - observables.tsv
+  sbml_files:
+  - model.xml

--- a/test/petab_select/0001/petab_select_problem.yaml
+++ b/test/petab_select/0001/petab_select_problem.yaml
@@ -1,0 +1,5 @@
+format_version: beta_1
+criterion: AIC
+method: brute_force
+model_space_files:
+- model_space.tsv

--- a/test/petab_select/0002/PEtab_select_forward_AIC.yaml
+++ b/test/petab_select/0002/PEtab_select_forward_AIC.yaml
@@ -1,0 +1,19 @@
+criteria:
+  AIC: -4.705325992131032
+  NLLH: -4.352662996065516
+estimated_parameters:
+  k1: 0.2016087801811796
+  sigma_x2: 0.11714048531059197
+model_hash: 3f82d81dfbb9f0c002cd9376252de3b9b9d2759533358d07dff9b7d823e000f747e8746a2599cff3da9882dca1899bd2ce5111399ff991a6aafe326b8c5d7042
+model_id: 3f82d81dfbb9f0c002cd9376252de3b9b9d2759533358d07dff9b7d823e000f747e8746a2599cff3da9882dca1899bd2ce5111399ff991a6aafe326b8c5d7042
+model_subspace_id: M1_3
+model_subspace_indices:
+- 0
+- 0
+- 0
+parameters:
+  k1: estimate
+  k2: 0.1
+  k3: 0
+petab_yaml: /home/sebpe/.julia/dev/PEtab/test/petab_select/0001/petab/petab_problem.yaml
+predecessor_model_hash: 311a4810ea1d385e0a587251e314476b981ae2ef1eb2e84472d68ad3632ea2bd4475fb6cadc14e61a0ef578fb0611b3e620d3d3db919680cf71e539752526f13

--- a/test/petab_select/0002/expected.yaml
+++ b/test/petab_select/0002/expected.yaml
@@ -1,0 +1,19 @@
+criteria:
+  AIC: -4.705325358569107
+  NLLH: -4.3526626792845535
+estimated_parameters:
+  k1: 0.20160877227137408
+  sigma_x2: 0.11715051179648493
+model_hash: 6fd0da92d615c00aecbce338a9346edf4e2c6a7136d406a1bc007f96265a59dd261890845bc5baaeeb5f422dd1813122eb5d9f605ddb02cd032841cc6aaaca2a
+model_id: 6fd0da92d615c00aecbce338a9346edf4e2c6a7136d406a1bc007f96265a59dd261890845bc5baaeeb5f422dd1813122eb5d9f605ddb02cd032841cc6aaaca2a
+model_subspace_id: M1_3
+model_subspace_indices:
+- 0
+- 0
+- 0
+parameters:
+  k1: estimate
+  k2: 0.1
+  k3: 0
+petab_yaml: ../0001/petab/petab_problem.yaml
+predecessor_model_hash: 1ba35a377e081501da8ea21c7bec90984baf680fdc0441e4d653350a0f03a27abccdaea569a116c0acc4cbfeb847ed460bc7e6035a229b0acfa0c078130b553a

--- a/test/petab_select/0002/model_space.tsv
+++ b/test/petab_select/0002/model_space.tsv
@@ -1,0 +1,9 @@
+model_subspace_id	petab_yaml	k1	k2	k3
+M1_0	../0001/petab/petab_problem.yaml	0	0	0
+M1_1	../0001/petab/petab_problem.yaml	0.2	0.1	estimate
+M1_2	../0001/petab/petab_problem.yaml	0.2	estimate	0
+M1_3	../0001/petab/petab_problem.yaml	estimate	0.1	0
+M1_4	../0001/petab/petab_problem.yaml	0.2	estimate	estimate
+M1_5	../0001/petab/petab_problem.yaml	estimate	0.1	estimate
+M1_6	../0001/petab/petab_problem.yaml	estimate	estimate	0
+M1_7	../0001/petab/petab_problem.yaml	estimate	estimate	estimate

--- a/test/petab_select/0002/petab_select_problem.yaml
+++ b/test/petab_select/0002/petab_select_problem.yaml
@@ -1,0 +1,5 @@
+format_version: beta_1
+criterion: AIC
+method: forward
+model_space_files:
+- model_space.tsv

--- a/test/petab_select/0003/PEtab_select_brute_force_BIC.yaml
+++ b/test/petab_select/0003/PEtab_select_brute_force_BIC.yaml
@@ -1,0 +1,18 @@
+criteria:
+  BIC: -6.383646027040346
+  NLLH: -4.0877027481342
+estimated_parameters:
+  sigma_x2: 0.12242920596801517
+model_hash: d6048fad45c78d4a60f35aebe324d95fef9cd08b84fb2eb52792916289a6433431a6a773fa58a97e54d8e8603e01b3e7547008baa6b551f2afcb155f363b656b
+model_id: d6048fad45c78d4a60f35aebe324d95fef9cd08b84fb2eb52792916289a6433431a6a773fa58a97e54d8e8603e01b3e7547008baa6b551f2afcb155f363b656b
+model_subspace_id: M1
+model_subspace_indices:
+- 1
+- 1
+- 0
+parameters:
+  k1: 0.2
+  k2: 0.1
+  k3: 0
+petab_yaml: /home/sebpe/.julia/dev/PEtab/test/petab_select/0001/petab/petab_problem.yaml
+predecessor_model_hash: null

--- a/test/petab_select/0003/expected.yaml
+++ b/test/petab_select/0003/expected.yaml
@@ -1,0 +1,18 @@
+criteria:
+  BIC: -6.383646149270872
+  NLLH: -4.087702809249463
+estimated_parameters:
+  sigma_x2: 0.12245324237132274
+model_hash: a56fafb3d43e25d3231e6f77d6b62e816bce3010fd0913fba51b67c35c9c281f77e8ffeb504e429c36b65e42c7f8617e6ea57d0a9ba416736e4ee60db9592056
+model_id: a56fafb3d43e25d3231e6f77d6b62e816bce3010fd0913fba51b67c35c9c281f77e8ffeb504e429c36b65e42c7f8617e6ea57d0a9ba416736e4ee60db9592056
+model_subspace_id: M1
+model_subspace_indices:
+- 1
+- 1
+- 0
+parameters:
+  k1: 0.2
+  k2: 0.1
+  k3: 0
+petab_yaml: ../0001/petab/petab_problem.yaml
+predecessor_model_hash: null

--- a/test/petab_select/0003/model_space.tsv
+++ b/test/petab_select/0003/model_space.tsv
@@ -1,0 +1,2 @@
+model_subspace_id	petab_yaml	k1	k2	k3
+M1	../0001/petab/petab_problem.yaml	0;0.2;estimate	0;0.1;estimate	0;estimate

--- a/test/petab_select/0003/petab_select_problem.yaml
+++ b/test/petab_select/0003/petab_select_problem.yaml
@@ -1,0 +1,5 @@
+format_version: beta_1
+criterion: BIC
+method: brute_force
+model_space_files:
+- model_space.tsv

--- a/test/petab_select/0004/PEtab_select_backward_AICc.yaml
+++ b/test/petab_select/0004/PEtab_select_backward_AICc.yaml
@@ -1,0 +1,19 @@
+criteria:
+  AICc: -0.7053255585809382
+  NLLH: -4.352662779290469
+estimated_parameters:
+  k1: 0.20160877989275575
+  sigma_x2: 0.11716228295703017
+model_hash: e088338b98c820f1b022c9ee7e3276444380566db237be00abedae78b98db40846598c663569272cc8f61d17fb9370cae01bd8f06a1c96ab919f5eb4e78cbfd9
+model_id: e088338b98c820f1b022c9ee7e3276444380566db237be00abedae78b98db40846598c663569272cc8f61d17fb9370cae01bd8f06a1c96ab919f5eb4e78cbfd9
+model_subspace_id: M1_3
+model_subspace_indices:
+- 0
+- 0
+- 0
+parameters:
+  k1: estimate
+  k2: 0.1
+  k3: 0
+petab_yaml: /home/sebpe/.julia/dev/PEtab/test/petab_select/0001/petab/petab_problem.yaml
+predecessor_model_hash: 20348748f4cada0c9fbf9429b944385b44d6c1c72d5d760a3a24350bd3221350b65930c230be600570aafa3a4539c14ee9b4c66c1fdda482a1d208ca7aff049c

--- a/test/petab_select/0004/constraints.tsv
+++ b/test/petab_select/0004/constraints.tsv
@@ -1,0 +1,2 @@
+YAML	if	constraint
+petab_1/petab_1.yaml	k1 <= k2	k1 < k2 && k3 == 0

--- a/test/petab_select/0004/expected.yaml
+++ b/test/petab_select/0004/expected.yaml
@@ -1,0 +1,19 @@
+criteria:
+  AICc: -0.7053253858878037
+  NLLH: -4.352662692943902
+estimated_parameters:
+  k1: 0.20160877435934813
+  sigma_x2: 0.11714883276066365
+model_hash: bc5e8327701472fef89052d8fe1f6e6bd0e31b86a927bef6d54cf418b769a45c7eaae2ca5f1b260e33743f138ce5f6c01c24eb7fa43f51a1e52ed8831f309c69
+model_id: bc5e8327701472fef89052d8fe1f6e6bd0e31b86a927bef6d54cf418b769a45c7eaae2ca5f1b260e33743f138ce5f6c01c24eb7fa43f51a1e52ed8831f309c69
+model_subspace_id: M1_3
+model_subspace_indices:
+- 0
+- 0
+- 0
+parameters:
+  k1: estimate
+  k2: 0.1
+  k3: 0
+petab_yaml: ../0001/petab/petab_problem.yaml
+predecessor_model_hash: 4884e4fce86df0d45d24bb23bfc4a4fa9b3b2de4d58c7baed06615ac6055557cce47a0c44b172eaee453826c7babda9dafcfc360ad72a0286eaa7a805d974488

--- a/test/petab_select/0004/model_space.tsv
+++ b/test/petab_select/0004/model_space.tsv
@@ -1,0 +1,9 @@
+model_subspace_id	petab_yaml	k1	k2	k3
+M1_0	../0001/petab/petab_problem.yaml	0	0	0
+M1_1	../0001/petab/petab_problem.yaml	0.2	0.1	estimate
+M1_2	../0001/petab/petab_problem.yaml	0.2	estimate	0
+M1_3	../0001/petab/petab_problem.yaml	estimate	0.1	0
+M1_4	../0001/petab/petab_problem.yaml	0.2	estimate	estimate
+M1_5	../0001/petab/petab_problem.yaml	estimate	0.1	estimate
+M1_6	../0001/petab/petab_problem.yaml	estimate	estimate	0
+M1_7	../0001/petab/petab_problem.yaml	estimate	estimate	estimate

--- a/test/petab_select/0004/petab_select_problem.yaml
+++ b/test/petab_select/0004/petab_select_problem.yaml
@@ -1,0 +1,7 @@
+format_version: beta_1
+criterion: AICc
+method: backward
+model_space_files:
+- model_space.tsv
+constraint_files:
+- constraints.tsv

--- a/test/petab_select/0005/PEtab_select_forward_AIC.yaml
+++ b/test/petab_select/0005/PEtab_select_forward_AIC.yaml
@@ -1,0 +1,19 @@
+criteria:
+  AIC: -4.705325989475844
+  NLLH: -4.352662994737922
+estimated_parameters:
+  k1: 0.20160874485551092
+  sigma_x2: 0.11713987072316094
+model_hash: 3b949986c694333275f2ab0bde14c206e0c78941c34503c910f43402ad5f3a7c601c5ce4789f0ee83b48fe2db0ed99b45648017f0e7f0b3c6df99f3c628ce1e4
+model_id: 3b949986c694333275f2ab0bde14c206e0c78941c34503c910f43402ad5f3a7c601c5ce4789f0ee83b48fe2db0ed99b45648017f0e7f0b3c6df99f3c628ce1e4
+model_subspace_id: M1_3
+model_subspace_indices:
+- 0
+- 0
+- 0
+parameters:
+  k1: estimate
+  k2: 0.1
+  k3: 0
+petab_yaml: /home/sebpe/.julia/dev/PEtab/test/petab_select/0001/petab/petab_problem.yaml
+predecessor_model_hash: e77eee60947ae6a0e46530a738612eb5579efb0742e5cf65e3a60ad247617f519f50e3bacc717642684670f1cc46d7716d5471e1167afddbf2d030c6c5ded239

--- a/test/petab_select/0005/expected.yaml
+++ b/test/petab_select/0005/expected.yaml
@@ -1,0 +1,19 @@
+criteria:
+  AIC: -4.705325086169246
+  NLLH: -4.352662543084623
+estimated_parameters:
+  k1: 0.20160877910494426
+  sigma_x2: 0.11716072823171682
+model_hash: 41ab831961ee3e1bb3918796fc85941ca5d59c90e9c867278daa5c9f5ba7fc707fa9da35f093706a671890b500cdb657d75d7f30ccc3b2ec072d1ddb28b40e2f
+model_id: 41ab831961ee3e1bb3918796fc85941ca5d59c90e9c867278daa5c9f5ba7fc707fa9da35f093706a671890b500cdb657d75d7f30ccc3b2ec072d1ddb28b40e2f
+model_subspace_id: M1_3
+model_subspace_indices:
+- 0
+- 0
+- 0
+parameters:
+  k1: estimate
+  k2: 0.1
+  k3: 0
+petab_yaml: ../0001/petab/petab_problem.yaml
+predecessor_model_hash: eef6129f57cab797a8c82d3e7c4a919e52d6ae155fe7a982485dd5cbb7eb2dab869bcec5e99ccca1867f749df79529d2758c0c687cfccee703392847a58edbc7

--- a/test/petab_select/0005/initial_models.tsv
+++ b/test/petab_select/0005/initial_models.tsv
@@ -1,0 +1,2 @@
+model_subspace_id	YAML	k1	k2	k3
+I1_6	../0001/petab/petab_problem.yaml	estimate	estimate	0

--- a/test/petab_select/0005/model_space.tsv
+++ b/test/petab_select/0005/model_space.tsv
@@ -1,0 +1,9 @@
+model_subspace_id	petab_yaml	k1	k2	k3
+M1_0	../0001/petab/petab_problem.yaml	0	0	0
+M1_1	../0001/petab/petab_problem.yaml	0.2	0.1	estimate
+M1_2	../0001/petab/petab_problem.yaml	0.2	estimate	0
+M1_3	../0001/petab/petab_problem.yaml	estimate	0.1	0
+M1_4	../0001/petab/petab_problem.yaml	0.2	estimate	estimate
+M1_5	../0001/petab/petab_problem.yaml	estimate	0.1	estimate
+M1_6	../0001/petab/petab_problem.yaml	estimate	estimate	0
+M1_7	../0001/petab/petab_problem.yaml	estimate	estimate	estimate

--- a/test/petab_select/0005/petab_select_problem.yaml
+++ b/test/petab_select/0005/petab_select_problem.yaml
@@ -1,0 +1,7 @@
+format_version: beta_1
+criterion: AIC
+method: forward
+model_space_files:
+- model_space.tsv
+initial_model_files:
+- initial_models.tsv

--- a/test/petab_select/0006/PEtab_select_forward_AIC.yaml
+++ b/test/petab_select/0006/PEtab_select_forward_AIC.yaml
@@ -1,0 +1,18 @@
+criteria:
+  AIC: -6.175405496268397
+  NLLH: -4.087702748134198
+estimated_parameters:
+  sigma_x2: 0.12242920622342243
+model_hash: abd0aee9e723c8700b150d6126c1e3de1e5405ed4a66601dd9a0941ed611a661276fc7a04915ca17927c585f3ff55ecc5901525d798d9577c21cc11e4d92496f
+model_id: abd0aee9e723c8700b150d6126c1e3de1e5405ed4a66601dd9a0941ed611a661276fc7a04915ca17927c585f3ff55ecc5901525d798d9577c21cc11e4d92496f
+model_subspace_id: M1_0
+model_subspace_indices:
+- 0
+- 0
+- 0
+parameters:
+  k1: 0.2
+  k2: 0.1
+  k3: 0
+petab_yaml: /home/sebpe/.julia/dev/PEtab/test/petab_select/0001/petab/petab_problem.yaml
+predecessor_model_hash: virtual_initial_model

--- a/test/petab_select/0006/expected.yaml
+++ b/test/petab_select/0006/expected.yaml
@@ -1,0 +1,18 @@
+criteria:
+  AIC: -6.175403277446156
+  NLLH: -4.087701638723078
+estimated_parameters:
+  sigma_x2: 0.12248840167611977
+model_hash: 0b5666da87c6c243d9e9fb85f7db5a7e12e733b522dd7caf688fea23cbcbb2e6f5cd345753820355d6472e595d6ccd30e96024ada3e66981fbe41c073f218da5
+model_id: 0b5666da87c6c243d9e9fb85f7db5a7e12e733b522dd7caf688fea23cbcbb2e6f5cd345753820355d6472e595d6ccd30e96024ada3e66981fbe41c073f218da5
+model_subspace_id: M1_0
+model_subspace_indices:
+- 0
+- 0
+- 0
+parameters:
+  k1: 0.2
+  k2: 0.1
+  k3: 0
+petab_yaml: ../0001/petab/petab_problem.yaml
+predecessor_model_hash: virtual_initial_model

--- a/test/petab_select/0006/model_space.tsv
+++ b/test/petab_select/0006/model_space.tsv
@@ -1,0 +1,9 @@
+model_subspace_id	petab_yaml	k1	k2	k3
+M1_0	../0001/petab/petab_problem.yaml	0.2	0.1	0
+M1_1	../0001/petab/petab_problem.yaml	0.2	0.1	estimate
+M1_2	../0001/petab/petab_problem.yaml	0.2	estimate	0
+M1_3	../0001/petab/petab_problem.yaml	estimate	0.1	0
+M1_4	../0001/petab/petab_problem.yaml	0.2	estimate	estimate
+M1_5	../0001/petab/petab_problem.yaml	estimate	0.1	estimate
+M1_6	../0001/petab/petab_problem.yaml	estimate	estimate	0
+M1_7	../0001/petab/petab_problem.yaml	estimate	estimate	estimate

--- a/test/petab_select/0006/petab_select_problem.yaml
+++ b/test/petab_select/0006/petab_select_problem.yaml
@@ -1,0 +1,5 @@
+format_version: beta_1
+criterion: AIC
+method: forward
+model_space_files:
+- model_space.tsv

--- a/test/petab_select/0007/PEtab_select_forward_AIC.yaml
+++ b/test/petab_select/0007/PEtab_select_forward_AIC.yaml
@@ -1,0 +1,17 @@
+criteria:
+  AIC: 11.117195861667307
+  NLLH: 5.5585979308336535
+estimated_parameters: {}
+model_hash: fbb5b6bcfad5f3524a104290e89989ed7c89a4a903034cb0f11d760b98976654f43d0bd93411251e93f28a6b2bd39a7e950e0593678646942cae3e850a1f5073
+model_id: fbb5b6bcfad5f3524a104290e89989ed7c89a4a903034cb0f11d760b98976654f43d0bd93411251e93f28a6b2bd39a7e950e0593678646942cae3e850a1f5073
+model_subspace_id: M1_0
+model_subspace_indices:
+- 0
+- 0
+- 0
+parameters:
+  k1: 0.2
+  k2: 0.1
+  k3: 0
+petab_yaml: /home/sebpe/.julia/dev/PEtab/test/petab_select/0007/petab/petab_problem.yaml
+predecessor_model_hash: virtual_initial_model

--- a/test/petab_select/0007/expected.yaml
+++ b/test/petab_select/0007/expected.yaml
@@ -1,0 +1,17 @@
+criteria:
+  AIC: 11.117195852885663
+  NLLH: 5.558597926442832
+estimated_parameters: {}
+model_hash: 76cd33b4662f5d1aeab6a06c4aea1a74d7ed1d937c8302d4d12d4f4bc30638a52c0e5e7a30b7647aca928813e2b845db1447cfa224f8eec49d6012a541073344
+model_id: 76cd33b4662f5d1aeab6a06c4aea1a74d7ed1d937c8302d4d12d4f4bc30638a52c0e5e7a30b7647aca928813e2b845db1447cfa224f8eec49d6012a541073344
+model_subspace_id: M1_0
+model_subspace_indices:
+- 0
+- 0
+- 0
+parameters:
+  k1: 0.2
+  k2: 0.1
+  k3: 0
+petab_yaml: petab/petab_problem.yaml
+predecessor_model_hash: virtual_initial_model

--- a/test/petab_select/0007/model_space.tsv
+++ b/test/petab_select/0007/model_space.tsv
@@ -1,0 +1,9 @@
+model_subspace_id	petab_yaml	k1	k2	k3
+M1_0	petab/petab_problem.yaml	0.2	0.1	0
+M1_1	petab/petab_problem.yaml	0.2	0.1	estimate
+M1_2	petab/petab_problem.yaml	0.2	estimate	0
+M1_3	petab/petab_problem.yaml	estimate	0.1	0
+M1_4	petab/petab_problem.yaml	0.2	estimate	estimate
+M1_5	petab/petab_problem.yaml	estimate	0.1	estimate
+M1_6	petab/petab_problem.yaml	estimate	estimate	0
+M1_7	petab/petab_problem.yaml	estimate	estimate	estimate

--- a/test/petab_select/0007/petab/Julia_model_files/petab.jl
+++ b/test/petab_select/0007/petab/Julia_model_files/petab.jl
@@ -1,0 +1,32 @@
+function get_reaction_system(foo)
+
+	ModelingToolkit.@variables t
+	sps = Catalyst.@species x1(t) x2(t) 
+	vs = ModelingToolkit.@variables observable_x2(t)
+	ps = Catalyst.@parameters k3 k1 k2 default 
+
+	D = Differential(t)
+
+	_reactions = [
+		Catalyst.Reaction(default*((((k3)*(x1))*(x2))/(default)), [x1, x2], nothing, [1.0/default, 1.0/default], nothing; only_use_rate=true),
+		Catalyst.Reaction(default*((k1)/(default)), nothing, [x1], nothing, [1.0/default]; only_use_rate=true),
+		Catalyst.Reaction(default*(((k2)*(x1))/(default)), [x1], [x2], [1.0/default], [1.0/default]; only_use_rate=true),
+		D(observable_x2) ~ 0.0,
+	]
+
+
+	rn = Catalyst.ReactionSystem(_reactions, t, [sps; vs], ps; name=Symbol("caroModel"), combinatoric_ratelaws=false)
+
+	specie_map = [
+	x1 =>0.0,
+	x2 =>0.0,
+	observable_x2 => 0.0,
+	]
+	parameter_map = [
+	k3 =>0.0,
+	k1 =>0.2,
+	k2 =>0.1,
+	default =>1.0,
+	]
+	return rn, specie_map, parameter_map
+end

--- a/test/petab_select/0007/petab/Julia_model_files/petab_D_h_sd.jl
+++ b/test/petab_select/0007/petab/Julia_model_files/petab_D_h_sd.jl
@@ -1,0 +1,36 @@
+#u[1] = x1, u[2] = x2, u[3] = observable_x2
+#p_ode_problem[1] = k3, p_ode_problem[2] = k1, p_ode_problem[3] = k2, p_ode_problem[4] = default
+#
+function compute_∂h∂u!(u, t::Real, p_ode_problem::AbstractVector, θ_observable::AbstractVector,
+                  θ_non_dynamic::AbstractVector, observableId::Symbol, parameter_map::θObsOrSdParameterMap, out) 
+	if observableId == :obs_x2 
+		out[2] = 1
+		return nothing
+	end
+
+end
+
+function compute_∂h∂p!(u, t::Real, p_ode_problem::AbstractVector, θ_observable::AbstractVector,
+                  θ_non_dynamic::AbstractVector, observableId::Symbol, parameter_map::θObsOrSdParameterMap, out) 
+	if observableId == :obs_x2 
+		return nothing
+	end
+
+end
+
+function compute_∂σ∂σu!(u, t::Real, θ_sd::AbstractVector, p_ode_problem::AbstractVector,  θ_non_dynamic::AbstractVector,
+                   parameter_info::ParametersInfo, observableId::Symbol, parameter_map::θObsOrSdParameterMap, out) 
+	if observableId == :obs_x2 
+		return nothing
+	end
+
+end
+
+function compute_∂σ∂σp!(u, t::Real, θ_sd::AbstractVector, p_ode_problem::AbstractVector,  θ_non_dynamic::AbstractVector,
+                   parameter_info::ParametersInfo, observableId::Symbol, parameter_map::θObsOrSdParameterMap, out) 
+	if observableId == :obs_x2 
+		return nothing
+	end
+
+end
+

--- a/test/petab_select/0007/petab/Julia_model_files/petab_callbacks.jl
+++ b/test/petab_select/0007/petab/Julia_model_files/petab_callbacks.jl
@@ -1,0 +1,11 @@
+
+
+function(foo)
+	return false 
+end
+
+
+
+function compute_tstops(u::AbstractVector, p::AbstractVector)
+	 return Float64[]
+end

--- a/test/petab_select/0007/petab/Julia_model_files/petab_h_sd_u0.jl
+++ b/test/petab_select/0007/petab/Julia_model_files/petab_h_sd_u0.jl
@@ -1,0 +1,48 @@
+#u[1] = x1, u[2] = x2, u[3] = observable_x2
+#p_ode_problem_names[1] = k3, p_ode_problem_names[2] = k1, p_ode_problem_names[3] = k2, p_ode_problem_names[4] = default
+#
+
+function compute_h(u::AbstractVector, t::Real, p_ode_problem::AbstractVector, θ_observable::AbstractVector,
+               θ_non_dynamic::AbstractVector, parameter_info::ParametersInfo, observableId::Symbol,
+                  parameter_map::θObsOrSdParameterMap)::Real 
+	if observableId === :obs_x2 
+		return u[2] 
+	end
+
+end
+
+function compute_u0!(u0::AbstractVector, p_ode_problem::AbstractVector) 
+
+	#p_ode_problem[1] = k3, p_ode_problem[2] = k1, p_ode_problem[3] = k2, p_ode_problem[4] = default
+
+	t = 0.0 # u at time zero
+
+	x1 = 0.0 
+	x2 = 0.0 
+	observable_x2 = 0.0 
+
+	u0 .= x1, x2, observable_x2
+end
+
+function compute_u0(p_ode_problem::AbstractVector)::AbstractVector 
+
+	#p_ode_problem[1] = k3, p_ode_problem[2] = k1, p_ode_problem[3] = k2, p_ode_problem[4] = default
+
+	t = 0.0 # u at time zero
+
+	x1 = 0.0 
+	x2 = 0.0 
+	observable_x2 = 0.0 
+
+	 return [x1, x2, observable_x2]
+end
+
+function compute_σ(u::AbstractVector, t::Real, θ_sd::AbstractVector, p_ode_problem::AbstractVector,  θ_non_dynamic::AbstractVector,
+               parameter_info::ParametersInfo, observableId::Symbol, parameter_map::θObsOrSdParameterMap)::Real 
+	if observableId === :obs_x2 
+		return 1.0 
+	end
+
+
+end
+

--- a/test/petab_select/0007/petab/conditions.tsv
+++ b/test/petab_select/0007/petab/conditions.tsv
@@ -1,0 +1,2 @@
+conditionId	conditionName
+model1_data1	condition1

--- a/test/petab_select/0007/petab/measurements.tsv
+++ b/test/petab_select/0007/petab/measurements.tsv
@@ -1,0 +1,7 @@
+observableId	simulationConditionId	measurement	time
+obs_x2	model1_data1	0	0
+obs_x2	model1_data1	0.19421762	1
+obs_x2	model1_data1	0.0484032	5
+obs_x2	model1_data1	0.61288016	10
+obs_x2	model1_data1	4.07930835	30
+obs_x2	model1_data1	10.12008893	60

--- a/test/petab_select/0007/petab/model.xml
+++ b/test/petab_select/0007/petab/model.xml
@@ -1,0 +1,300 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by COPASI version 4.24 (Build 197) on 2019-03-27 19:00 with libSBML version 5.17.0. -->
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" version="4">
+  <model metaid="COPASI0" id="caroModel_linear_petab_2" name="caroModel">
+    <annotation>
+      <COPASI xmlns="http://www.copasi.org/static/sbml">
+        <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+          <rdf:Description rdf:about="#COPASI0">
+            <dcterms:created>
+              <rdf:Description>
+                <dcterms:W3CDTF>2019-03-27T18:47:48Z</dcterms:W3CDTF>
+              </rdf:Description>
+            </dcterms:created>
+          </rdf:Description>
+        </rdf:RDF>
+      </COPASI>
+    </annotation>
+    <listOfFunctionDefinitions>
+      <functionDefinition metaid="COPASI10" id="function_for_R3" name="function for R3">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI10">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:57:38Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> k3 </ci>
+            </bvar>
+            <bvar>
+              <ci> x1 </ci>
+            </bvar>
+            <bvar>
+              <ci> x2 </ci>
+            </bvar>
+            <bvar>
+              <ci> default </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k3 </ci>
+                <ci> x1 </ci>
+                <ci> x2 </ci>
+              </apply>
+              <ci> default </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI11" id="function_for_R1" name="function for R1">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI11">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:52:47Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> k1 </ci>
+            </bvar>
+            <bvar>
+              <ci> default </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <ci> k1 </ci>
+              <ci> default </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI12" id="function_for_R2" name="function for R2">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI12">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:55:12Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> k2 </ci>
+            </bvar>
+            <bvar>
+              <ci> x1 </ci>
+            </bvar>
+            <bvar>
+              <ci> default </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k2 </ci>
+                <ci> x1 </ci>
+              </apply>
+              <ci> default </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+    </listOfFunctionDefinitions>
+    <listOfCompartments>
+      <compartment id="default" name="default" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="x1" name="x1" compartment="default" initialConcentration="0" boundaryCondition="false" constant="false"/>
+      <species id="x2" name="x2" compartment="default" initialConcentration="0" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter metaid="COPASI1" id="k1" name="k1" value="0.2" constant="true">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI1">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:59:36Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+      </parameter>
+      <parameter metaid="COPASI2" id="k2" name="k2" value="0.1" constant="true">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI2">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:59:35Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+      </parameter>
+      <parameter metaid="COPASI3" id="k3" name="k3" value="0" constant="true">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI3">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:59:34Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+      </parameter>
+      <parameter metaid="COPASI6" id="observable_x2" name="observable_x2" value="0" constant="false">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI6">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:50:50Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+      </parameter>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction metaid="COPASI7" id="R1" name="R1" reversible="false">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI7">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:53:29Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfProducts>
+          <speciesReference species="x1" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <apply>
+                <ci> function_for_R1 </ci>
+                <ci> k1 </ci>
+                <ci> default </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI8" id="R2" name="R2" reversible="false">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI8">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:55:51Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="x1" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="x2" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <apply>
+                <ci> function_for_R2 </ci>
+                <ci> k2 </ci>
+                <ci> x1 </ci>
+                <ci> default </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI9" id="R3" name="R3" reversible="false">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI9">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2019-03-27T18:49:35Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="x1" stoichiometry="1"/>
+          <speciesReference species="x2" stoichiometry="1"/>
+        </listOfReactants>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <apply>
+                <ci> function_for_R3 </ci>
+                <ci> k3 </ci>
+                <ci> x1 </ci>
+                <ci> x2 </ci>
+                <ci> default </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/petab_select/0007/petab/observables.tsv
+++ b/test/petab_select/0007/petab/observables.tsv
@@ -1,0 +1,2 @@
+observableId	observableFormula	noiseFormula
+obs_x2	x2	1

--- a/test/petab_select/0007/petab/parameters.tsv
+++ b/test/petab_select/0007/petab/parameters.tsv
@@ -1,0 +1,4 @@
+parameterId	parameterName	parameterScale	lowerBound	upperBound	nominalValue	estimate
+k1	k_{1}	lin	0	1.00E+03	0.2	1
+k2	k_{2}	lin	0	1.00E+03	0.1	1
+k3	k_{3}	lin	0	1.00E+03	0	1

--- a/test/petab_select/0007/petab/petab_problem.yaml
+++ b/test/petab_select/0007/petab/petab_problem.yaml
@@ -1,0 +1,11 @@
+format_version: 1
+parameter_file: parameters.tsv
+problems:
+- condition_files:
+  - conditions.tsv
+  measurement_files:
+  - measurements.tsv
+  observable_files:
+  - observables.tsv
+  sbml_files:
+  - model.xml

--- a/test/petab_select/0007/petab_select_problem.yaml
+++ b/test/petab_select/0007/petab_select_problem.yaml
@@ -1,0 +1,5 @@
+format_version: beta_1
+criterion: AIC
+method: forward
+model_space_files:
+- model_space.tsv

--- a/test/petab_select/0008/PEtab_select_backward_AICc.yaml
+++ b/test/petab_select/0008/PEtab_select_backward_AICc.yaml
@@ -1,0 +1,17 @@
+criteria:
+  AICc: 11.117195861667307
+  NLLH: 5.5585979308336535
+estimated_parameters: {}
+model_hash: 5b8d3b57800722ed299c9a33d68832f82467fdaf96d12d25ea5e4f06f9494134628c0218b9a0b690befa6bf0c475199d6b90765f1220fe8bb039abf5d195f8ac
+model_id: 5b8d3b57800722ed299c9a33d68832f82467fdaf96d12d25ea5e4f06f9494134628c0218b9a0b690befa6bf0c475199d6b90765f1220fe8bb039abf5d195f8ac
+model_subspace_id: M1_0
+model_subspace_indices:
+- 0
+- 0
+- 0
+parameters:
+  k1: 0.2
+  k2: 0.1
+  k3: 0
+petab_yaml: /home/sebpe/.julia/dev/PEtab/test/petab_select/0007/petab/petab_problem.yaml
+predecessor_model_hash: 11c67b4e4c71fd70d107d9c941cba84ac822900c852f4da7c843e1fbe69323abf097b2aec8f1ac99b90752b18798704b8f903a376d6cc7192b7e8bd25f5208fd

--- a/test/petab_select/0008/expected.yaml
+++ b/test/petab_select/0008/expected.yaml
@@ -1,0 +1,17 @@
+criteria:
+  AICc: 11.117195852885663
+  NLLH: 5.558597926442832
+estimated_parameters: {}
+model_hash: 55257e66db40f0afe00d8a79e7794512f9a1b784b6f3f46afda685d7da6d6b16972a126dc9ffc87194cd033d82c9899d9fb9516d085b418ba7684446943bfb09
+model_id: 55257e66db40f0afe00d8a79e7794512f9a1b784b6f3f46afda685d7da6d6b16972a126dc9ffc87194cd033d82c9899d9fb9516d085b418ba7684446943bfb09
+model_subspace_id: M1_0
+model_subspace_indices:
+- 0
+- 0
+- 0
+parameters:
+  k1: 0.2
+  k2: 0.1
+  k3: 0
+petab_yaml: ../0007/petab/petab_problem.yaml
+predecessor_model_hash: e90911f79cb469da6acd814744c6440dd449cc496ef56c4221956930fe41b4b7f561e61f8051112b87042764880b8650ee3c008c5dce973a4361a99694ab254b

--- a/test/petab_select/0008/model_space.tsv
+++ b/test/petab_select/0008/model_space.tsv
@@ -1,0 +1,9 @@
+model_subspace_id	petab_yaml	k1	k2	k3
+M1_0	../0007/petab/petab_problem.yaml	0.2	0.1	0
+M1_1	../0007/petab/petab_problem.yaml	0.2	0.1	estimate
+M1_2	../0007/petab/petab_problem.yaml	0.2	estimate	0
+M1_3	../0007/petab/petab_problem.yaml	estimate	0.1	0
+M1_4	../0007/petab/petab_problem.yaml	0.2	estimate	estimate
+M1_5	../0007/petab/petab_problem.yaml	estimate	0.1	estimate
+M1_6	../0007/petab/petab_problem.yaml	estimate	estimate	0
+M1_7	../0007/petab/petab_problem.yaml	estimate	estimate	estimate

--- a/test/petab_select/0008/petab_select_problem.yaml
+++ b/test/petab_select/0008/petab_select_problem.yaml
@@ -1,0 +1,5 @@
+format_version: beta_1
+criterion: AICc
+method: backward
+model_space_files:
+- model_space.tsv

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,13 @@
 using SafeTestsets
 
+
 @safetestset "Aqua Quality Check" begin
   include("Aqua.jl")
+end
+
+
+@safetestset "PEtab-select" begin
+  include("PEtab_select.jl")
 end
 
 @safetestset "Test model 2" begin


### PR DESCRIPTION
For getting reasonable codecov the PyCall extension needs to be tested.

This aims to test if I can get PyCall with `fides` and `petab-select` to work on GitHub CI.