### PR TITLE
Only use needed OrdinaryDiffEq packages

### DIFF
--- a/ext/PEtabSciMLSensitivityExtension.jl
+++ b/ext/PEtabSciMLSensitivityExtension.jl
@@ -3,7 +3,8 @@ module PEtabSciMLSensitivityExtension
 using SciMLBase
 using ModelingToolkit
 using DiffEqCallbacks
-using OrdinaryDiffEq
+using OrdinaryDiffEqBDF
+using OrdinaryDiffEqSDIRK
 using ForwardDiff
 using ReverseDiff
 using SciMLSensitivity

--- a/src/PEtab.jl
+++ b/src/PEtab.jl
@@ -3,7 +3,9 @@ module PEtab
 using ModelingToolkit
 using CSV
 using SciMLBase
-using OrdinaryDiffEq
+using OrdinaryDiffEqBDF
+using OrdinaryDiffEqRosenbrock
+using OrdinaryDiffEqSDIRK
 using Catalyst
 using ComponentArrays
 using DataFrames


### PR DESCRIPTION
This should reduce pre-compilation time, as now only the packages that contain the default solvers are loaded.

Closes #206 