### PR TITLE
Allow optional bounds if estimate = 0 for parameters

### DIFF
--- a/src/petab_files/common.jl
+++ b/src/petab_files/common.jl
@@ -1,9 +1,21 @@
-
 function _parse_table_column!(out::AbstractVector, dfcol, type)::Nothing
     @assert type in [Symbol, string, Float64, Bool]
     for (i, val) in pairs(dfcol)
         ismissing(val) && continue
         out[i] = val |> type
+    end
+    return nothing
+end
+
+function _parse_bound_column!(out::Vector{Float64}, dfcol, estimate::Vector{Bool})::Nothing
+    for (i, val) in pairs(dfcol)
+        if ismissing(val) && estimate[i] == false
+            continue
+        elseif ismissing(val)
+            throw(PEtabInputError("If a parameter does not have a bound " *
+                                  "then estimate = false for said parameter"))
+        end
+        out[i] = Float64(val)
     end
     return nothing
 end

--- a/src/petab_files/parameters.jl
+++ b/src/petab_files/parameters.jl
@@ -11,12 +11,12 @@ function PEtabParameters(parameters_df::DataFrame;
     paramter_scales = fill(Symbol(), nparameters)
     estimate = fill(false, nparameters)
 
-    _parse_table_column!(lower_bounds, parameters_df[!, :lowerBound], Float64)
-    _parse_table_column!(upper_bounds, parameters_df[!, :upperBound], Float64)
     _parse_table_column!(nominal_values, parameters_df[!, :nominalValue], Float64)
     _parse_table_column!(parameter_ids, parameters_df[!, :parameterId], Symbol)
     _parse_table_column!(paramter_scales, parameters_df[!, :parameterScale], Symbol)
     _parse_table_column!(estimate, parameters_df[!, :estimate], Bool)
+    _parse_bound_column!(lower_bounds, parameters_df[!, :lowerBound], estimate)
+    _parse_bound_column!(upper_bounds, parameters_df[!, :upperBound], estimate)
     nparameters_estimate = sum(estimate) |> Int64
 
     # When doing model selection it can be necessary to change the parameter values

--- a/src/petab_files/table_info.jl
+++ b/src/petab_files/table_info.jl
@@ -17,8 +17,8 @@ const CONDITIONS_COLS = Dict("conditionId" => (required = true, types = Abstract
 
 const PARAMETERS_COLS = Dict("parameterId" => (required = true, types = AbstractString),
                              "parameterScale" => (required = true, types = AbstractString),
-                             "lowerBound" => (required = true, types = Real),
-                             "upperBound" => (required = true, types = Real),
+                             "lowerBound" => (required = true, types = Union{Real, Missing}),
+                             "upperBound" => (required = true, types = Union{Real, Missing}),
                              "nominalValue" => (required = true, types = Real),
                              "estimate" => (required = true, types = Real),
                              "initializationPriorType" => (required = false,


### PR DESCRIPTION
For a PEtab problem it is valid to not specify bounds in the parameters table if estimate = false. This is added with this patch.