### PR TITLE
Refined cost function generators

### DIFF
--- a/src/derivatives/forward_eqs.jl
+++ b/src/derivatives/forward_eqs.jl
@@ -24,7 +24,7 @@ function _grad_forward_eqs!(grad::Vector{T}, _solve_conditions!::Function,
 
     fill!(grad, 0.0)
     for icid in eachindex(simulation_info.conditionids[:experiment])
-        if cids[1] != :all && !(imulation_info.conditionids[:experiment][cid] in cids)
+        if cids[1] != :all && !(simulation_info.conditionids[:experiment][icid] in cids)
             continue
         end
         _grad_forward_eqs_cond!(grad, xdynamic_ps, xnoise_ps, xobservable_ps,

--- a/src/derivatives/gauss_newton.jl
+++ b/src/derivatives/gauss_newton.jl
@@ -27,7 +27,7 @@ function _jac_residuals_xdynamic!(jac::AbstractMatrix, _solve_conditions!::Funct
 
     # Compute the gradient by looping through all experimental conditions.
     for icid in eachindex(simulation_info.conditionids[:experiment])
-        if cids[1] != :all && !(imulation_info.conditionids[:experiment][icid] in cids)
+        if cids[1] != :all && !(simulation_info.conditionids[:experiment][icid] in cids)
             continue
         end
         _jac_residuals_cond!(jac, xdynamic_ps, xnoise_ps, xobservable_ps, xnondynamic_ps,

--- a/src/petab_odeproblem/create.jl
+++ b/src/petab_odeproblem/create.jl
@@ -109,12 +109,12 @@ function _get_prior(model_info::ModelInfo)::Tuple{Function, Function, Function}
 end
 
 function _get_nllh(probinfo::PEtabODEProblemInfo, model_info::ModelInfo,
-                   prior::Function, residuals::Bool)::Function
-    _nllh = let pinfo = probinfo, minfo = model_info, res = residuals, _prior = prior
-        (x; prior = true) -> begin
+                   prior::Function, residuals::Bool; cids::AbstractVector{Symbol}=[:all])::Function
+    _nllh = let pinfo = probinfo, minfo = model_info, res = residuals, _prior = prior, Cids = cids
+        (x; prior = true, cids = Cids) -> begin
             _test_ordering(x, minfo.xindices.xids[:estimate_ps])
             _x = x |> collect
-            nllh_val = nllh(_x, pinfo, minfo, [:all], false, res)
+            nllh_val = nllh(_x, pinfo, minfo, cids, false, res)
             if prior == true && res == false
                 # nllh -> negative prior
                 return nllh_val - _prior(_x)
@@ -127,16 +127,16 @@ function _get_nllh(probinfo::PEtabODEProblemInfo, model_info::ModelInfo,
 end
 
 function _get_grad(method, probinfo::PEtabODEProblemInfo, model_info::ModelInfo,
-                   grad_prior::Function)::Tuple{Function, Function}
+                   grad_prior::Function; cids::AbstractVector{Symbol}=[:all])::Tuple{Function, Function}
     if probinfo.gradient_method == :ForwardDiff
-        _grad_nllh! = _get_grad_forward_AD(probinfo, model_info)
+        _grad_nllh! = _get_grad_forward_AD(probinfo, model_info; cids = cids)
     end
     if probinfo.gradient_method == :ForwardEquations
-        _grad_nllh! = _get_grad_forward_eqs(probinfo, model_info)
+        _grad_nllh! = _get_grad_forward_eqs(probinfo, model_info; cids = cids)
     end
 
-    _grad! = let _grad_nllh! = _grad_nllh!, grad_prior = grad_prior
-        (g, x; prior = true, isremade = false) -> begin
+    _grad! = let _grad_nllh! = _grad_nllh!, grad_prior = grad_prior, Cids = cids
+        (g, x; prior = true, isremade = false, cids = Cids) -> begin
             _x = x |> collect
             _g = similar(_x)
             _grad_nllh!(_g, _x; isremade = isremade)
@@ -148,8 +148,8 @@ function _get_grad(method, probinfo::PEtabODEProblemInfo, model_info::ModelInfo,
             return nothing
         end
     end
-    _grad = let _grad! = _grad!
-        (x; prior = true, isremade = false) -> begin
+    _grad = let _grad! = _grad!, Cids = cids
+        (x; prior = true, isremade = false, cids = Cids) -> begin
             gradient = similar(x)
             _grad!(gradient, x; prior = prior, isremade = isremade)
             return gradient
@@ -160,7 +160,7 @@ end
 
 function _get_hess(probinfo::PEtabODEProblemInfo, model_info::ModelInfo,
                    hess_prior::Function; ret_jacobian::Bool = false,
-                   FIM::Bool = false)::Tuple{Function, Function}
+                   FIM::Bool = false, cids::AbstractVector{Symbol}=[:all])::Tuple{Function, Function}
     @unpack hessian_method, split_over_conditions, chunksize, cache = probinfo
     @unpack xdynamic = cache
     if FIM == true
@@ -168,11 +168,11 @@ function _get_hess(probinfo::PEtabODEProblemInfo, model_info::ModelInfo,
     end
 
     if hessian_method === :ForwardDiff
-        _hess_nllh! = _get_hess_forward_AD(probinfo, model_info)
+        _hess_nllh! = _get_hess_forward_AD(probinfo, model_info; cids = cids)
     elseif hessian_method === :BlockForwardDiff
-        _hess_nllh! = _get_hess_block_forward_AD(probinfo, model_info)
+        _hess_nllh! = _get_hess_block_forward_AD(probinfo, model_info; cids = cids)
     elseif hessian_method == :GaussNewton
-        _hess_nllh! = _get_hess_gaussnewton(probinfo, model_info, ret_jacobian)
+        _hess_nllh! = _get_hess_gaussnewton(probinfo, model_info, ret_jacobian; cids = cids)
     end
 
     _hess! = let _hess_nllh! = _hess_nllh!, hess_prior = hess_prior

--- a/src/petab_odeproblem/create.jl
+++ b/src/petab_odeproblem/create.jl
@@ -179,7 +179,7 @@ function _get_hess(probinfo::PEtabODEProblemInfo, model_info::ModelInfo,
         (H, x; prior = true, isremade = false) -> begin
             _x = x |> collect
             _H = H |> collect
-            if hessian_method == :GassNewton
+            if hessian_method == :GaussNewton
                 _hess_nllh!(_H, _x; isremade = isremade)
             else
                 _hess_nllh!(_H, _x)

--- a/src/petab_odeproblem/derivative_functions.jl
+++ b/src/petab_odeproblem/derivative_functions.jl
@@ -3,11 +3,11 @@
 =#
 
 function _get_grad_forward_AD(probinfo::PEtabODEProblemInfo,
-                              model_info::ModelInfo)::Function
+                              model_info::ModelInfo; cids::AbstractVector{Symbol}=[:all])::Function
     @unpack split_over_conditions, gradient_method, chunksize = probinfo
     @unpack sensealg, cache = probinfo
     _nllh_not_solveode = _get_nllh_not_solveode(probinfo, model_info;
-                                                grad_forward_AD = true)
+                                                grad_forward_AD = true, cids = cids)
 
     if split_over_conditions == false
         _nllh_solveode = _get_nllh_solveode(probinfo, model_info; grad_xdynamic = true)
@@ -39,7 +39,7 @@ function _get_grad_forward_AD(probinfo::PEtabODEProblemInfo,
 end
 
 function _get_grad_forward_eqs(probinfo::PEtabODEProblemInfo,
-                               model_info::ModelInfo)::Function
+                               model_info::ModelInfo; cids::AbstractVector{Symbol}=[:all])::Function
     @unpack split_over_conditions, gradient_method, chunksize = probinfo
     @unpack sensealg, cache = probinfo
     @unpack xdynamic, odesols = cache
@@ -70,15 +70,15 @@ function _get_grad_forward_eqs(probinfo::PEtabODEProblemInfo,
     end
 
     _nllh_not_solveode = _get_nllh_not_solveode(probinfo, model_info;
-                                                grad_forward_eqs = true)
+                                                grad_forward_eqs = true, cids = cids)
 
     _grad! = let _nllh_not_solveode = _nllh_not_solveode,
         _solve_conditions! = _solve_conditions!, minfo = model_info, pinfo = probinfo,
-        cfg = cfg
+        cfg = cfg, Cids = cids
 
-        (g, x; isremade = false) -> grad_forward_eqs!(g, x, _nllh_not_solveode,
+        (g, x; isremade = false, cids = Cids) -> grad_forward_eqs!(g, x, _nllh_not_solveode,
                                                       _solve_conditions!, pinfo, minfo,
-                                                      cfg; cids = [:all],
+                                                      cfg; cids = cids,
                                                       isremade = isremade)
     end
     return _grad!
@@ -89,11 +89,11 @@ end
 =#
 
 function _get_hess_forward_AD(probinfo::PEtabODEProblemInfo,
-                              model_info::ModelInfo)::Function
+                              model_info::ModelInfo; cids::AbstractVector{Symbol}=[:all])::Function
     @unpack split_over_conditions, chunksize = probinfo
     if split_over_conditions == false
-        _nllh = let pinfo = probinfo, minfo = model_info
-            (x) -> nllh(x, pinfo, minfo, [:all], true, false)
+        _nllh = let pinfo = probinfo, minfo = model_info, Cids = cids
+            (x) -> nllh(x, pinfo, minfo, Cids, true, false)
         end
         nestimate = length(model_info.xindices.xids[:estimate])
         chunksize_use = _get_chunksize(chunksize, zeros(nestimate))
@@ -115,28 +115,28 @@ function _get_hess_forward_AD(probinfo::PEtabODEProblemInfo,
 end
 
 function _get_hess_block_forward_AD(probinfo::PEtabODEProblemInfo,
-                                    model_info::ModelInfo)::Function
+                                    model_info::ModelInfo; cids::AbstractVector{Symbol}=[:all])::Function
     @unpack split_over_conditions, chunksize = probinfo
     xdynamic = probinfo.cache.xdynamic
 
     _nllh_not_solveode = _get_nllh_not_solveode(probinfo, model_info;
-                                                grad_forward_AD = true)
+                                                grad_forward_AD = true, cids = cids)
 
     if split_over_conditions == false
-        _nllh_solveode = let pinfo = probinfo, minfo = model_info
+        _nllh_solveode = let pinfo = probinfo, minfo = model_info, Cids = cids
             @unpack xnoise, xobservable, xnondynamic = pinfo.cache
             (x) -> nllh_solveode(x, xnoise, xobservable, xnondynamic, pinfo, minfo;
-                                 grad_xdynamic = true, cids = [:all])
+                                 grad_xdynamic = true, cids = Cids)
         end
 
         chunksize_use = _get_chunksize(chunksize, xdynamic)
         cfg = ForwardDiff.HessianConfig(_nllh_solveode, xdynamic, chunksize_use)
         _hess_nllh! = let _nllh_solveode = _nllh_solveode,
-            _nllh_not_solveode = _nllh_not_solveode, pinfo = probinfo, minfo = model_info,
+            _nllh_not_solveode = _nllh_not_solveode, pinfo = probinfo, minfo = model_info, Cids = cids,
             cfg = cfg
 
             (H, x) -> hess_block!(H, x, _nllh_not_solveode, _nllh_solveode, pinfo,
-                                  minfo, cfg; cids = [:all])
+                                  minfo, cfg; cids = Cids)
         end
     end
 
@@ -150,23 +150,23 @@ function _get_hess_block_forward_AD(probinfo::PEtabODEProblemInfo,
         end
 
         _hess_nllh! = let _nllh_solveode = _nllh_solveode,
-            _nllh_not_solveode = _nllh_not_solveode, pinfo = probinfo, minfo = model_info
+            _nllh_not_solveode = _nllh_not_solveode, pinfo = probinfo, minfo = model_info, Cids = cids
 
             (H, x) -> hess_block_split!(H, x, _nllh_not_solveode, _nllh_solveode,
-                                        pinfo, minfo; cids = [:all])
+                                        pinfo, minfo; cids = Cids)
         end
     end
     return _hess_nllh!
 end
 
 function _get_hess_gaussnewton(probinfo::PEtabODEProblemInfo, model_info::ModelInfo,
-                               ret_jacobian::Bool)::Function
+                               ret_jacobian::Bool; cids::AbstractVector{Symbol}=[:all])::Function
     @unpack split_over_conditions, chunksize, cache = probinfo
     xdynamic = probinfo.cache.xdynamic
 
     if split_over_conditions == false
-        _solve_conditions! = let pinfo = probinfo, minfo = model_info
-            (sols, x) -> solve_conditions!(sols, x, pinfo, minfo; cids = [:all],
+        _solve_conditions! = let pinfo = probinfo, minfo = model_info, Cids = cids
+            (sols, x) -> solve_conditions!(sols, x, pinfo, minfo; cids = Cids,
                                            sensitivites_AD = true)
         end
     end
@@ -181,13 +181,13 @@ function _get_hess_gaussnewton(probinfo::PEtabODEProblemInfo, model_info::ModelI
                                            cache.odesols,
                                            cache.xdynamic, chunksize_use)
 
-    _residuals_not_solveode = let pinfo = probinfo, minfo = model_info
+    _residuals_not_solveode = let pinfo = probinfo, minfo = model_info, Cids = cids
         ixnoise = minfo.xindices.xindices_notsys[:noise]
         ixobservable = minfo.xindices.xindices_notsys[:observable]
         ixnondynamic = minfo.xindices.xindices_notsys[:nondynamic]
         (residuals, x) -> begin
             residuals_not_solveode(residuals, x[ixnoise], x[ixobservable],
-                                   x[ixnondynamic], pinfo, minfo; cids = [:all])
+                                   x[ixnondynamic], pinfo, minfo; cids = Cids)
         end
     end
 
@@ -197,11 +197,11 @@ function _get_hess_gaussnewton(probinfo::PEtabODEProblemInfo, model_info::ModelI
                                               ForwardDiff.Chunk(xnot_ode))
     _hess_nllh! = let _residuals_not_solveode = _residuals_not_solveode,
         pinfo = probinfo, minfo = model_info, cfg = cfg, cfg_notsolve = cfg_notsolve,
-        ret_jacobian = ret_jacobian, _solve_conditions! = _solve_conditions!
+        ret_jacobian = ret_jacobian, _solve_conditions! = _solve_conditions!, Cids = cids
 
         (H, x; isremade = false) -> hess_GN!(H, x, _residuals_not_solveode,
                                              _solve_conditions!, pinfo, minfo, cfg,
-                                             cfg_notsolve; cids = [:all],
+                                             cfg_notsolve; cids = Cids,
                                              isremade = isremade,
                                              ret_jacobian = ret_jacobian)
     end
@@ -214,13 +214,13 @@ end
 
 function _get_nllh_not_solveode(probinfo::PEtabODEProblemInfo, model_info::ModelInfo;
                                 grad_forward_AD::Bool = false, grad_adjoint::Bool = false,
-                                grad_forward_eqs::Bool = false)::Function
-    _nllh_not_solveode = let pinfo = probinfo, minfo = model_info
+                                grad_forward_eqs::Bool = false, cids::AbstractVector{Symbol}=[:all])::Function
+    _nllh_not_solveode = let pinfo = probinfo, minfo = model_info, Cids = cids
         ixnoise = minfo.xindices.xindices_notsys[:noise]
         ixobservable = minfo.xindices.xindices_notsys[:observable]
         ixnondynamic = minfo.xindices.xindices_notsys[:nondynamic]
         (x) -> nllh_not_solveode(x[ixnoise], x[ixobservable], x[ixnondynamic], pinfo, minfo;
-                                 cids = [:all], grad_forward_AD = grad_forward_AD,
+                                 cids = Cids, grad_forward_AD = grad_forward_AD,
                                  grad_forward_eqs = grad_forward_eqs,
                                  grad_adjoint = grad_adjoint)
     end


### PR DESCRIPTION
Allows for specification of kwarg `cids::AbstractVector{Symbol}` in `_get_nllh`, `_get_grad`, `_get_hess` and others to enable generating cost functions (and their gradients / Hessians) for specific subsets of interesting conditions, i.e. allowing for individual conditions to be toggled on or off during optimization while reusing the existing codebase.

To my knowledge, these changes should not affect any behaviour of the original methods with current usage.
Also fixes some typos causing bugs with gradient and Hessian calculations.

So far, I tested this for `gradient_method=:ForwardEquations` and `hessian_method=:GaussNewton` or `hessian_method=:ForwardDiff`.
I know that `gradient_method=:ForwardDiff` definitely does not work yet. 
@sebapersson Maybe it is easier for you to add the missing kwarg extensions for the remaining gradient and Hessian methods than it is for me to reverse engineer them? Would be greatly appreciated!