### PR TITLE
Update LinearSolve.jl version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PEtab"
 uuid = "48d54b35-e43e-4a66-a5a1-dde6b987cf69"
-version = "3.9.3"
+version = "3.9.4"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -82,7 +82,7 @@ FiniteDifferences = "0.12"
 ForwardDiff = "0.10"
 Ipopt = "1"
 LinearAlgebra = "1"
-LinearSolve = "3.15 - 3.17.0"
+LinearSolve = "3.20"
 LogDensityProblems = "2.1"
 LogDensityProblemsAD = "1.7"
 MCMCChains = "7"


### PR DESCRIPTION
Version 3.20 resolved the `ForwardDiff.hessian` bug.