### PR TITLE
Make simulated_values(x) return new vector

### DIFF
--- a/src/parameter_estimation/startguesses.jl
+++ b/src/parameter_estimation/startguesses.jl
@@ -1,5 +1,5 @@
 """
-    get_startguesses(rng::AbstractRNG, prob::PEtabODEProblem, n::Integer; kwargs...)
+    get_startguesses([rng::AbstractRNG], prob::PEtabODEProblem, n::Integer; kwargs...)
 
 Generate `n` random parameter vectors within the parameter bounds in `prob`.
 
@@ -28,8 +28,7 @@ function get_startguesses(prob::PEtabODEProblem, n::Integer; sample_prior::Bool 
                           sampling_method::SamplingAlgorithm = LatinHypercubeSample())
     rng = Random.default_rng()
     return get_startguesses(rng, prob, n; sample_prior = sample_prior,
-                            allow_inf = allow_inf,
-                            sampling_method = sampling_method)
+                            allow_inf = allow_inf, sampling_method = sampling_method)
 end
 function get_startguesses(rng::Random.AbstractRNG, prob::PEtabODEProblem, n::Integer;
                           sample_prior::Bool = true, allow_inf::Bool = false,

--- a/src/petab_odeproblem/create.jl
+++ b/src/petab_odeproblem/create.jl
@@ -67,7 +67,7 @@ function PEtabODEProblem(model::PEtabModel;
         end
         _simulated_values = (x) -> begin
             _ = nllh(x)
-            return model_info.petab_measurements.simulated_values
+            return deepcopy(model_info.petab_measurements.simulated_values)
         end
     end
     _logging(:Build_chi2_res_sim, verbose; time = btime)


### PR DESCRIPTION
Currently the same internal Vector is returned, which is not ideal (e.g., confuse users testing if perturbing parameters perturb simulated values)